### PR TITLE
Change API Test URL

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -80,7 +80,7 @@ class Config:
     def test_api_connection(self, connection):
         try:
             response = requests.get(
-                f"{connection['url']}/system/status",
+                f"{connection['url']}/api",
                 params={"apiKey": connection["api_key"]},
                 headers={"Content-Type": "application/json"},
             )


### PR DESCRIPTION
When using basic auth, /system/status won't allow you to browse this URL with an API key.