### PR TITLE
chore: Pin pytest-mock dependency to 3.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ PyYAML==6.0.2
 requests==2.32.3
 tautulli==4.3.4.2140
 trakt.py==4.4.0
-pytest-mock
+pytest-mock==3.14.1


### PR DESCRIPTION
## Summary
- Pins `pytest-mock` to version 3.14.1 for reproducible builds
- Ensures consistent test behavior across all environments

## Test plan
- [x] Verify CI tests pass with pinned version
- [x] Check that pytest-mock functionality works correctly