### PR TITLE
fix: Replace mutable default argument with None

### DIFF
--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -378,11 +378,13 @@ class MediaCleaner:
         guid=None,
         title=None,
         year=None,
-        alternate_titles=[],
+        alternate_titles=None,
         imdb_id=None,
         tvdb_id=None,
         tmdb_id=None,
     ):
+        if alternate_titles is None:
+            alternate_titles = []
         if guid:
             plex_media_item = self.find_by_guid(plex_library, guid)
             if plex_media_item:


### PR DESCRIPTION
## Summary
- Fixes mutable default argument anti-pattern in `get_plex_item()` function
- Changes `alternate_titles=[]` to `alternate_titles=None` with runtime initialization
- Prevents potential bugs from shared mutable state across function calls

## Background
In Python, mutable default arguments (like `[]` or `{}`) are evaluated once at function definition time, not at call time. This means the same list object would be reused across all calls, which can lead to unexpected behavior if the list is modified.

## Test plan
- [x] Verify existing tests pass
- [x] Confirm `alternate_titles` behavior is unchanged