### PR TITLE
build(docker): update python to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-alpine
+FROM python:3.12-alpine
 
 LABEL maintainer="rfsbraz"
 


### PR DESCRIPTION
The introduction of JustWatchAPI in v0.0.20 broke the Docker image because an operator is being used, but it is not in Python 3.9. As such, I have updated it to 3.12, to match your previous commits (https://github.com/rfsbraz/deleterr/commit/7dc9ff3579dde9edee66db18b55a9e777596da74 and https://github.com/rfsbraz/deleterr/commit/a46de8a3ba366107349b852d68df7a894d472e76)

Both v0.0.20 and v0.0.21 exit with the following type error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/app/app/deleterr.py", line 12, in <module>
    from app.media_cleaner import MediaCleaner
  File "/app/app/media_cleaner.py", line 9, in <module>
    from app.modules.justwatch import JustWatch
  File "/app/app/modules/justwatch.py", line 1, in <module>
    from simplejustwatchapi.justwatch import search
  File "/usr/local/lib/python3.9/site-packages/simplejustwatchapi/__init__.py", line 1, in <module>
    from simplejustwatchapi.justwatch import search
  File "/usr/local/lib/python3.9/site-packages/simplejustwatchapi/justwatch.py", line 7, in <module>
    from simplejustwatchapi.query import MediaEntry, parse_search_response, prepare_search_request
  File "/usr/local/lib/python3.9/site-packages/simplejustwatchapi/query.py", line 91, in <module>
    class Offer(NamedTuple):
  File "/usr/local/lib/python3.9/site-packages/simplejustwatchapi/query.py", line 99, in Offer
    price_string: str | None
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

I believe the bitwise or operator became usable for type unions in Python 3.10. However, updating to 3.12 would align with tests and SonarQube. 