### PR TITLE
Remove interactive mode

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -57,10 +57,6 @@ class Config:
         if self.settings.get("dry_run"):
             logger.info("Running in dry-run mode, no changes will be made.")
 
-        if self.settings.get("interactive"):
-            logger.info(
-                "Running in interactive mode, you will be prompted before any changes are made."
-            )
 
     def log_and_exit(self, msg):
         logger.error(msg)

--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -234,23 +234,10 @@ class MediaCleaner:
             print_readable_freed_space(disk_size),
             total_episodes,
         )
-        deleted = False
-        if self.config.settings.get("interactive"):
-            logger.info(
-                "Would you like to delete show '%s' from sonarr instance '%s'? (y/n)",
-                sonarr_show["title"],
-                library.get("name"),
-            )
-            if input().lower() == "y":
-                self.delete_series(sonarr_instance, sonarr_show)
-                deleted = True
-        else:
-            self.delete_series(sonarr_instance, sonarr_show)
-            deleted = True
+        self.delete_series(sonarr_instance, sonarr_show)
 
         # Update Overseerr status after successful deletion
-        if deleted:
-            self._update_overseerr_status(library, sonarr_show, "tv")
+        self._update_overseerr_status(library, sonarr_show, "tv")
 
     def process_library_movies(self, library, radarr_instance):
         if not library_meets_disk_space_threshold(library, radarr_instance):
@@ -396,31 +383,14 @@ class MediaCleaner:
             library.get("name"),
             print_readable_freed_space(disk_size),
         )
-        deleted = False
-        if self.config.settings.get("interactive"):
-            logger.info(
-                "Would you like to delete movie '%s' from radarr instance '%s'? (y/n)",
-                radarr_movie["title"],
-                library.get("name"),
-            )
-            if input().lower() == "y":
-                radarr_instance.del_movie(
-                    radarr_movie["id"],
-                    delete_files=True,
-                    add_exclusion=library.get("add_list_exclusion_on_delete", False),
-                )
-                deleted = True
-        else:
-            radarr_instance.del_movie(
-                radarr_movie["id"],
-                delete_files=True,
-                add_exclusion=library.get("add_list_exclusion_on_delete", False),
-            )
-            deleted = True
+        radarr_instance.del_movie(
+            radarr_movie["id"],
+            delete_files=True,
+            add_exclusion=library.get("add_list_exclusion_on_delete", False),
+        )
 
         # Update Overseerr status after successful deletion
-        if deleted:
-            self._update_overseerr_status(library, radarr_movie, "movie")
+        self._update_overseerr_status(library, radarr_movie, "movie")
 
     def _update_overseerr_status(self, library, media_data, media_type):
         """

--- a/app/schema.py
+++ b/app/schema.py
@@ -443,10 +443,6 @@ class DeleterrConfig(BaseModel):
         default=True,
         description="If true, actions are only logged, not performed",
     )
-    interactive: bool = Field(
-        default=False,
-        description="If true, prompts for confirmation before each action",
-    )
     ssl_verify: bool = Field(
         default=False,
         description="Enable SSL certificate verification for API connections",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,7 +23,6 @@ Root-level settings that apply globally.
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `dry_run` | boolean | No | `true` | If true, actions are only logged, not performed |
-| `interactive` | boolean | No | `false` | If true, prompts for confirmation before each action |
 | `ssl_verify` | boolean | No | `false` | Enable SSL certificate verification for API connections |
 | `action_delay` | integer | No | `0` | Delay (in seconds) between actions. Increase if Plex/Sonarr/Radarr timeout on remote mounts |
 | `plex_library_scan_after_actions` | boolean | No | `false` | Trigger a Plex library scan after actions are performed |
@@ -33,7 +32,6 @@ Root-level settings that apply globally.
 dry_run: true
 ssl_verify: false
 action_delay: 25
-interactive: false
 plex_library_scan_after_actions: false
 tautulli_library_scan_after_actions: false
 ```

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -193,7 +193,6 @@ Root-level settings that apply globally.
 dry_run: true
 ssl_verify: false
 action_delay: 25
-interactive: false
 plex_library_scan_after_actions: false
 tautulli_library_scan_after_actions: false
 ```
@@ -577,7 +576,7 @@ libraries:
 """
 
     # Generate general settings table (subset of DeleterrConfig)
-    general_fields = ["dry_run", "interactive", "ssl_verify", "action_delay",
+    general_fields = ["dry_run", "ssl_verify", "action_delay",
                       "plex_library_scan_after_actions", "tautulli_library_scan_after_actions"]
     general_lines = ["| Property | Type | Required | Default | Description |"]
     general_lines.append("|----------|------|----------|---------|-------------|")

--- a/tests/integration/configs/add_list_exclusion.yaml
+++ b/tests/integration/configs/add_list_exclusion.yaml
@@ -2,7 +2,6 @@
 # Tests: Deleted movies should be added to Radarr's exclusion list
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/added_at_threshold.yaml
+++ b/tests/integration/configs/added_at_threshold.yaml
@@ -2,7 +2,6 @@
 # Tests: Recently added items (within 7 days) should be protected from deletion
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/anime_series.yaml
+++ b/tests/integration/configs/anime_series.yaml
@@ -2,7 +2,6 @@
 # Tests: Only anime series should be affected (not standard series)
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/basic_movie_deletion.yaml
+++ b/tests/integration/configs/basic_movie_deletion.yaml
@@ -2,7 +2,6 @@
 # Tests: Movies older than 30 days since last watched are deleted
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/basic_series_deletion.yaml
+++ b/tests/integration/configs/basic_series_deletion.yaml
@@ -2,7 +2,6 @@
 # Tests: TV shows older than 30 days since last watched are deleted
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/collection_threshold.yaml
+++ b/tests/integration/configs/collection_threshold.yaml
@@ -2,7 +2,6 @@
 # Tests: If any item in a collection was recently watched, protect the entire collection
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/combined_exclusions.yaml
+++ b/tests/integration/configs/combined_exclusions.yaml
@@ -2,7 +2,6 @@
 # Tests: Multiple exclusion rules can be combined
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/dry_run_mode.yaml
+++ b/tests/integration/configs/dry_run_mode.yaml
@@ -2,7 +2,6 @@
 # Tests: Nothing should be deleted when dry_run is enabled
 
 dry_run: true
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/exclusions_by_collection.yaml
+++ b/tests/integration/configs/exclusions_by_collection.yaml
@@ -2,7 +2,6 @@
 # Tests: Movies in specific collections should be protected from deletion
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/exclusions_by_genre.yaml
+++ b/tests/integration/configs/exclusions_by_genre.yaml
@@ -2,7 +2,6 @@
 # Tests: Movies with specific genres should be protected from deletion
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/exclusions_by_justwatch.yaml
+++ b/tests/integration/configs/exclusions_by_justwatch.yaml
@@ -2,7 +2,6 @@
 # Tests: Movies available on streaming services should be protected from deletion
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/exclusions_by_label.yaml
+++ b/tests/integration/configs/exclusions_by_label.yaml
@@ -2,7 +2,6 @@
 # Tests: Movies with specific Plex labels should be protected from deletion
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/exclusions_by_release_year.yaml
+++ b/tests/integration/configs/exclusions_by_release_year.yaml
@@ -2,7 +2,6 @@
 # Tests: Movies released in the last N years should be protected from deletion
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/exclusions_by_title.yaml
+++ b/tests/integration/configs/exclusions_by_title.yaml
@@ -2,7 +2,6 @@
 # Tests: Specific titles should be protected from deletion
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/max_actions_limit.yaml
+++ b/tests/integration/configs/max_actions_limit.yaml
@@ -2,7 +2,6 @@
 # Tests: Deletion should stop after max_actions_per_run is reached
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/multi_instance.yaml
+++ b/tests/integration/configs/multi_instance.yaml
@@ -2,7 +2,6 @@
 # Tests: Multiple Radarr/Sonarr instances can be managed
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/sort_by_added_date_asc.yaml
+++ b/tests/integration/configs/sort_by_added_date_asc.yaml
@@ -2,7 +2,6 @@
 # Tests: Oldest added items should be deleted first
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/sort_by_size_desc.yaml
+++ b/tests/integration/configs/sort_by_size_desc.yaml
@@ -2,7 +2,6 @@
 # Tests: Largest items should be deleted first
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/watch_status_unwatched.yaml
+++ b/tests/integration/configs/watch_status_unwatched.yaml
@@ -2,7 +2,6 @@
 # Tests: Only delete movies that have never been watched
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/configs/watch_status_watched.yaml
+++ b/tests/integration/configs/watch_status_watched.yaml
@@ -2,7 +2,6 @@
 # Tests: Only delete movies that have been watched (not unwatched ones)
 
 dry_run: false
-interactive: false
 action_delay: 0
 
 plex:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -396,7 +396,6 @@ def integration_config(docker_services):
     """
     return {
         "dry_run": True,  # Default to dry run for safety
-        "interactive": False,
         "action_delay": 0,
         "plex": {
             "url": PLEX_MOCK_URL,

--- a/tests/integration/test_deleterr_deletion.py
+++ b/tests/integration/test_deleterr_deletion.py
@@ -16,10 +16,9 @@ pytestmark = pytest.mark.integration
 class MockConfig:
     """Mock config object for MediaCleaner tests."""
 
-    def __init__(self, dry_run=False, interactive=False, action_delay=0):
+    def __init__(self, dry_run=False, action_delay=0):
         self.settings = {
             "dry_run": dry_run,
-            "interactive": interactive,
             "action_delay": action_delay,
         }
 

--- a/tests/integration/test_media_cleaner.py
+++ b/tests/integration/test_media_cleaner.py
@@ -756,8 +756,7 @@ class TestDryRunMode:
         mock_config = MagicMock()
         mock_config.settings = {
             "dry_run": True,
-            "interactive": False,
-            "plex": {"url": "http://localhost:32400", "token": "test"},
+                        "plex": {"url": "http://localhost:32400", "token": "test"},
             "tautulli": {"url": "http://localhost:8181", "api_key": "test"},
         }
 
@@ -793,8 +792,7 @@ class TestMaxActionsPerRun:
         mock_config = MagicMock()
         mock_config.settings = {
             "dry_run": True,  # Use dry run so we don't actually delete
-            "interactive": False,
-            "action_delay": 0,
+                        "action_delay": 0,
             "plex": {"url": "http://localhost:32400", "token": "test"},
             "tautulli": {"url": "http://localhost:8181", "api_key": "test"},
         }
@@ -849,8 +847,7 @@ class TestAddListExclusion:
         mock_config = MagicMock()
         mock_config.settings = {
             "dry_run": False,
-            "interactive": False,
-            "plex": {"url": "http://localhost:32400", "token": "test"},
+                        "plex": {"url": "http://localhost:32400", "token": "test"},
             "tautulli": {"url": "http://localhost:8181", "api_key": "test"},
         }
 

--- a/tests/test_media_cleaner.py
+++ b/tests/test_media_cleaner.py
@@ -378,72 +378,6 @@ def test_process_show_not_dry_run(mock_delete_show_if_allowed, standard_config):
     assert result == 100
 
 
-@patch.object(MediaCleaner, "delete_series")
-@patch("builtins.input", return_value="y")
-def test_delete_show_if_allowed_interactive_yes(
-    mock_input, mock_delete_series, standard_config
-):
-    # Arrange
-    library = {"name": "Test Library"}
-    sonarr_instance = MagicMock()
-    sonarr_show = {"title": "Test Show"}
-    actions_performed = 0
-    max_actions_per_run = 1
-    disk_size = 100
-    total_episodes = 10
-
-    media_cleaner = MediaCleaner(standard_config)
-    media_cleaner.config.settings = {"interactive": True}
-
-    # Act
-    media_cleaner.delete_show_if_allowed(
-        library,
-        sonarr_instance,
-        sonarr_show,
-        actions_performed,
-        max_actions_per_run,
-        disk_size,
-        total_episodes,
-    )
-
-    # Assert
-    mock_delete_series.assert_called_once_with(sonarr_instance, sonarr_show)
-    mock_input.assert_called_once_with()
-
-
-@patch.object(MediaCleaner, "delete_series")
-@patch("builtins.input", return_value="n")
-def test_delete_show_if_allowed_not_interactive_yes(
-    mock_input, mock_delete_series, standard_config
-):
-    # Arrange
-    library = {"name": "Test Library"}
-    sonarr_instance = MagicMock()
-    sonarr_show = {"title": "Test Show"}
-    actions_performed = 0
-    max_actions_per_run = 1
-    disk_size = 100
-    total_episodes = 10
-
-    media_cleaner = MediaCleaner(standard_config)
-    media_cleaner.config.settings = {"interactive": False}
-
-    # Act
-    media_cleaner.delete_show_if_allowed(
-        library,
-        sonarr_instance,
-        sonarr_show,
-        actions_performed,
-        max_actions_per_run,
-        disk_size,
-        total_episodes,
-    )
-
-    # Assert
-    mock_delete_series.assert_called_once_with(sonarr_instance, sonarr_show)
-    mock_input.assert_not_called()
-
-
 def test_check_exclusions(mocker, standard_config):
     # Arrange
     library = {"name": "Test Library", "exclude": {}}
@@ -1036,8 +970,7 @@ def test_delete_series_no_errors(standard_config):
     mock_sonarr.del_series.assert_called_once_with(sonarr_show["id"], delete_files=True)
 
 
-@patch("builtins.input", return_value="y")
-def test_delete_movie_if_allowed_interactive_yes(mock_input, standard_config):
+def test_delete_movie_if_allowed(standard_config):
     # Arrange
     library = {"name": "Test Library"}
     radarr_instance = MagicMock()
@@ -1047,64 +980,6 @@ def test_delete_movie_if_allowed_interactive_yes(mock_input, standard_config):
     disk_size = 100
 
     media_cleaner_instance = MediaCleaner(standard_config)
-    media_cleaner_instance.config.settings = {"interactive": True}
-
-    # Act
-    media_cleaner_instance.delete_movie_if_allowed(
-        library,
-        radarr_instance,
-        radarr_movie,
-        actions_performed,
-        max_actions_per_run,
-        disk_size,
-    )
-
-    # Assert
-    mock_input.assert_called_once()
-    radarr_instance.del_movie.assert_called_once_with(
-        radarr_movie["id"], delete_files=True, add_exclusion=False
-    )
-
-
-@patch("builtins.input", return_value="n")
-def test_delete_movie_if_allowed_interactive_no(mock_input, standard_config):
-    # Arrange
-    library = {"name": "Test Library"}
-    radarr_instance = MagicMock()
-    radarr_movie = {"id": 1, "title": "Test Movie"}
-    actions_performed = 0
-    max_actions_per_run = 1
-    disk_size = 100
-
-    media_cleaner_instance = MediaCleaner(standard_config)
-    media_cleaner_instance.config.settings = {"interactive": True}
-
-    # Act
-    media_cleaner_instance.delete_movie_if_allowed(
-        library,
-        radarr_instance,
-        radarr_movie,
-        actions_performed,
-        max_actions_per_run,
-        disk_size,
-    )
-
-    # Assert
-    mock_input.assert_called_once()
-    radarr_instance.del_movie.assert_not_called()
-
-
-def test_delete_movie_if_allowed_not_interactive(standard_config):
-    # Arrange
-    library = {"name": "Test Library"}
-    radarr_instance = MagicMock()
-    radarr_movie = {"id": 1, "title": "Test Movie"}
-    actions_performed = 0
-    max_actions_per_run = 1
-    disk_size = 100
-
-    media_cleaner_instance = MediaCleaner(standard_config)
-    media_cleaner_instance.config.settings = {"interactive": False}
 
     # Act
     media_cleaner_instance.delete_movie_if_allowed(


### PR DESCRIPTION
## Summary
- Remove the `interactive` configuration option that prompted for confirmation before each deletion action
- Simplifies code by removing input() prompts in deletion workflows
- Updates documentation and test configs to remove references to interactive mode

Closes #90

## Test plan
- [x] Unit tests pass (125 tests)
- [x] Python syntax validation passes
- [ ] CI tests should pass