### PR TITLE
docs: Add environment variables documentation

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,6 +16,46 @@ Complete reference for all Deleterr configuration options.
 
 ---
 
+## Environment Variables
+
+You can use environment variables in your configuration file using the `!env` tag. This is useful for keeping sensitive information like API keys and tokens out of your configuration file.
+
+```yaml
+plex:
+  url: "http://localhost:32400"
+  token: !env PLEX_TOKEN
+
+tautulli:
+  url: "http://localhost:8181"
+  api_key: !env TAUTULLI_API_KEY
+
+radarr:
+  - name: "Radarr"
+    url: "http://localhost:7878"
+    api_key: !env RADARR_API_KEY
+```
+
+When using Docker, you can pass environment variables using the `-e` flag:
+
+```bash
+docker run -e PLEX_TOKEN=your_token -e TAUTULLI_API_KEY=your_key ...
+```
+
+Or in a `docker-compose.yml`:
+
+```yaml
+services:
+  deleterr:
+    image: ghcr.io/rfsbraz/deleterr:latest
+    environment:
+      - PLEX_TOKEN=your_token
+      - TAUTULLI_API_KEY=your_key
+```
+
+> **Note**: If an environment variable is not set, Deleterr will fail to start with an error message indicating which variable is missing.
+
+---
+
 ## General Settings
 
 Root-level settings that apply globally.

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -183,6 +183,46 @@ Complete reference for all Deleterr configuration options.
 
 ---
 
+## Environment Variables
+
+You can use environment variables in your configuration file using the `!env` tag. This is useful for keeping sensitive information like API keys and tokens out of your configuration file.
+
+```yaml
+plex:
+  url: "http://localhost:32400"
+  token: !env PLEX_TOKEN
+
+tautulli:
+  url: "http://localhost:8181"
+  api_key: !env TAUTULLI_API_KEY
+
+radarr:
+  - name: "Radarr"
+    url: "http://localhost:7878"
+    api_key: !env RADARR_API_KEY
+```
+
+When using Docker, you can pass environment variables using the `-e` flag:
+
+```bash
+docker run -e PLEX_TOKEN=your_token -e TAUTULLI_API_KEY=your_key ...
+```
+
+Or in a `docker-compose.yml`:
+
+```yaml
+services:
+  deleterr:
+    image: ghcr.io/rfsbraz/deleterr:latest
+    environment:
+      - PLEX_TOKEN=your_token
+      - TAUTULLI_API_KEY=your_key
+```
+
+> **Note**: If an environment variable is not set, Deleterr will fail to start with an error message indicating which variable is missing.
+
+---
+
 ## General Settings
 
 Root-level settings that apply globally.


### PR DESCRIPTION
## Summary
- Documents the `!env` YAML tag feature added in eaf522333248780ee55a15d8a044fbf543fb6aae
- Adds examples showing how to use environment variables in configuration files
- Explains error handling when environment variables are not set

## Test plan
- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm examples are accurate and follow existing documentation style