### PR TITLE
fix(ci): prevent duplicate Docker comments on PRs

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -28,4 +28,4 @@ jobs:
             ```
 
             > **Note:** This image is built for `linux/amd64` only. The image is pushed to GHCR (not Docker Hub) for PR testing.
-          comment_tag: docker_image_instructions
+          comment-tag: docker_image_instructions


### PR DESCRIPTION
## Summary
Fix the PR comment workflow creating duplicate comments on every push.

## Problem
The `comment-pr.yml` workflow uses `comment_tag` (underscore) but the `thollander/actions-comment-pull-request@v3` action requires `comment-tag` (hyphen) to identify and update existing comments.

## Solution
Change `comment_tag` to `comment-tag` so the action properly updates the existing comment instead of creating a new one on every push.

## Evidence
See PR #174 which has 10+ duplicate Docker instruction comments.