### PR TITLE
fix: add missing del_movie method and __getattr__ safeguard

### DIFF
--- a/app/modules/radarr.py
+++ b/app/modules/radarr.py
@@ -12,6 +12,22 @@ class DRadarr:
 
         self.instance = RadarrAPI(radarr_url, radarr_api_key)
 
+    def __getattr__(self, name):
+        """Delegate unknown attributes to the underlying RadarrAPI instance.
+
+        This is a safeguard to prevent AttributeError when wrapper methods
+        are missing. It logs a warning so developers know to add an explicit
+        wrapper method.
+        """
+        if hasattr(self.instance, name):
+            logger.warning(
+                "DRadarr.%s() not explicitly defined, delegating to RadarrAPI. "
+                "Consider adding an explicit wrapper method.",
+                name
+            )
+            return getattr(self.instance, name)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
     def get_movies(self):
         return self.instance.get_movie()
 
@@ -51,6 +67,9 @@ class DRadarr:
 
     def get_disk_space(self):
         return self.instance.get_disk_space()
+
+    def del_movie(self, movie_id, delete_files=False, add_exclusion=False):
+        return self.instance.del_movie(movie_id, delete_files=delete_files, add_exclusion=add_exclusion)
 
     def validate_connection(self):
         try:

--- a/app/modules/sonarr.py
+++ b/app/modules/sonarr.py
@@ -12,6 +12,22 @@ class DSonarr:
 
         self.instance = SonarrAPI(sonarr_url, sonarr_api_key)
 
+    def __getattr__(self, name):
+        """Delegate unknown attributes to the underlying SonarrAPI instance.
+
+        This is a safeguard to prevent AttributeError when wrapper methods
+        are missing. It logs a warning so developers know to add an explicit
+        wrapper method.
+        """
+        if hasattr(self.instance, name):
+            logger.warning(
+                "DSonarr.%s() not explicitly defined, delegating to SonarrAPI. "
+                "Consider adding an explicit wrapper method.",
+                name
+            )
+            return getattr(self.instance, name)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
     def get_series(self):
         return self.instance.get_series()
 


### PR DESCRIPTION
## Summary
- Added missing `del_movie()` method to `DRadarr` wrapper class
- Added `__getattr__` delegation to both `DRadarr` and `DSonarr` as a safeguard against future missing wrapper methods

## Problem
When running with `dry_run: false`, deleting movies failed with:
```
AttributeError: 'DRadarr' object has no attribute 'del_movie'
```

## Solution
1. **Immediate fix**: Added the missing `del_movie()` method
2. **Preventive measure**: Added `__getattr__` to both wrapper classes that:
   - Delegates undefined method calls to the underlying pyarr instance (prevents crashes)
   - Logs a warning so developers know to add an explicit wrapper method

This means if we miss a wrapper method in the future, the app will still work but log warnings like:
```
WARNING: DRadarr.some_method() not explicitly defined, delegating to RadarrAPI. Consider adding an explicit wrapper method.
```

## Test plan
- [x] Unit tests for `del_movie()` method
- [x] Unit tests for `__getattr__` delegation behavior
- [x] Integration test for `DRadarr.del_movie()` with real Radarr

Fixes #180