### PR TITLE
fix: use PAT for release-please to trigger Docker builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,6 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Use PAT to ensure tag pushes trigger downstream workflows (e.g., Docker image builds)
+          # GITHUB_TOKEN doesn't trigger workflows on tags it creates (security feature)
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
Use a Personal Access Token (PAT) for release-please instead of the default GITHUB_TOKEN.

## Problem
Docker images weren't being built/tagged when release-please created new releases. This is because `GITHUB_TOKEN` doesn't trigger downstream workflows when it pushes tags (GitHub security feature to prevent infinite loops).

## Solution
Use a PAT (`RELEASE_PLEASE_TOKEN`) which allows the tag push to trigger the docker-image workflow properly.

## Setup Required
A fine-grained PAT with the following permissions has been added as `RELEASE_PLEASE_TOKEN`:
- Contents: Read and write
- Pull requests: Read and write  
- Workflows: Read and write