### PR TITLE
fix: exit with non-zero code on configuration errors

### DIFF
--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -1169,6 +1169,11 @@ def _get_config_value(config, key, default=None):
     return config[key] if key in config else default
 
 
+class ConfigurationError(Exception):
+    """Raised when there's a configuration error that prevents processing."""
+    pass
+
+
 def library_meets_disk_space_threshold(library, dpyarr_instance):
     for item in library.get("disk_size_threshold", []):
         path = item.get("path")
@@ -1188,8 +1193,8 @@ def library_meets_disk_space_threshold(library, dpyarr_instance):
                     )
                     return False
         if not folder_found:
-            logger.error(
-                f"Could not find folder '{path}' in server instance. Skipping library '{library.get('name')}'"
+            raise ConfigurationError(
+                f"Could not find folder '{path}' in server instance for library '{library.get('name')}'. "
+                f"Check that the path matches a root folder in your Radarr/Sonarr settings."
             )
-            return False
     return True

--- a/tests/test_media_cleaner.py
+++ b/tests/test_media_cleaner.py
@@ -8,6 +8,7 @@ from pyarr.exceptions import PyarrResourceNotFound, PyarrServerError
 import app.media_cleaner
 from app.config import Config
 from app.media_cleaner import (
+    ConfigurationError,
     DEFAULT_MAX_ACTIONS_PER_RUN,
     MediaCleaner,
     check_excluded_radarr_fields,
@@ -66,7 +67,10 @@ class TestLibraryMeetsDiskSpaceThreshold(unittest.TestCase):
         self.pyarr.get_disk_space.return_value = [
             {"path": "/data/media/other", "freeSpace": 500000000000}
         ]
-        self.assertFalse(library_meets_disk_space_threshold(self.library, self.pyarr))
+        with self.assertRaises(ConfigurationError) as context:
+            library_meets_disk_space_threshold(self.library, self.pyarr)
+        self.assertIn("/data/media/local", str(context.exception))
+        self.assertIn("Test Library", str(context.exception))
 
     def test_unset_disk_size_threshold(self):
         del self.library["disk_size_threshold"]


### PR DESCRIPTION
## Summary

When all libraries fail due to configuration errors (e.g., invalid `disk_size_threshold` path), deleterr now exits with code 1 instead of code 0. This prevents infinite restart loops when using container restart policies like `restart: unless-stopped`.

## Problem

Previously, if the `disk_size_threshold` path didn't exist in Radarr/Sonarr, deleterr would:
1. Log an error
2. Skip the library
3. Exit with code 0 (success)
4. Container restarts due to restart policy
5. Repeat forever

## Solution

- Add `ConfigurationError` exception for config-related failures
- Track successful vs failed libraries
- Exit with code 1 if **all** libraries failed due to config errors
- In scheduler mode with `run_on_startup`, exit if initial run fails due to config errors
- Fix APScheduler API compatibility issue

The error message now includes actionable guidance:
```
Could not find folder '/data' in server instance for library 'Movies'.
Check that the path matches a root folder in your Radarr/Sonarr settings.
```

## Behavior

| Scenario | Old Behavior | New Behavior |
|----------|--------------|--------------|
| All libraries fail (config error) | Exit 0, restart loop | Exit 1, stop |
| Some libraries fail | Exit 0 | Exit 0 (partial success) |
| Disk space above threshold | Exit 0 | Exit 0 (expected) |
| Scheduler + run_on_startup + config error | Loop forever | Exit 1 |

## Test plan

- [x] Unit tests updated and passing
- [x] Tested locally with invalid path config