### PR TITLE
fix: add dry-run indicator to summary log messages

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -51,10 +51,16 @@ class Deleterr:
                         logger.error(str(e))
                         self.libraries_failed += 1
 
-            logger.info(
-                "Freed %s of space by deleting movies",
-                print_readable_freed_space(saved_space),
-            )
+            if self.config.settings.get("dry_run"):
+                logger.info(
+                    "[DRY-RUN] Would have freed %s of space by deleting movies",
+                    print_readable_freed_space(saved_space),
+                )
+            else:
+                logger.info(
+                    "Freed %s of space by deleting movies",
+                    print_readable_freed_space(saved_space),
+                )
 
     def process_sonarr(self):
         for name, sonarr in self.sonarr.items():
@@ -73,10 +79,16 @@ class Deleterr:
                         logger.error(str(e))
                         self.libraries_failed += 1
 
-            logger.info(
-                "Freed %s of space by deleting shows",
-                print_readable_freed_space(saved_space),
-            )
+            if self.config.settings.get("dry_run"):
+                logger.info(
+                    "[DRY-RUN] Would have freed %s of space by deleting shows",
+                    print_readable_freed_space(saved_space),
+                )
+            else:
+                logger.info(
+                    "Freed %s of space by deleting shows",
+                    print_readable_freed_space(saved_space),
+                )
 
     def has_fatal_errors(self):
         """Returns True if all libraries failed due to configuration errors."""

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -115,7 +115,10 @@ class DeleterrScheduler:
                     "Please check your settings.yaml and fix the errors above."
                 )
                 return False
-            logger.info("Scheduled run completed successfully")
+            if self.config.settings.get("dry_run"):
+                logger.info("[DRY-RUN] Scheduled run completed successfully (no changes were made)")
+            else:
+                logger.info("Scheduled run completed successfully")
             return True
         except Exception as e:
             logger.error(f"Scheduled run failed: {e}")


### PR DESCRIPTION
## Summary

- Adds `[DRY-RUN]` prefix to "Freed X of space" messages when running in dry-run mode
- Changes wording to "Would have freed" instead of "Freed" in dry-run mode  
- Adds dry-run indicator to "Scheduled run completed" message

This prevents users from being misled into thinking actual deletions occurred when viewing logs from a dry-run.

## Test plan

- [x] Existing tests pass
- [ ] Verify log output shows `[DRY-RUN] Would have freed X of space by deleting shows/movies` when dry_run is enabled
- [ ] Verify log output shows `[DRY-RUN] Scheduled run completed successfully (no changes were made)` when dry_run is enabled
- [ ] Verify original messages appear when dry_run is disabled