### PR TITLE
perf(tautulli): eliminate unnecessary metadata API calls

### DIFF
--- a/tests/test_sort_media.py
+++ b/tests/test_sort_media.py
@@ -225,20 +225,26 @@ class TestLastWatchedSort:
         sorted_list = sort_media(media_list, sort_config, activity_data, plex_guid_item_pair)
         titles = [item["sortTitle"] for item in sorted_list]
 
-        # C is unwatched (infinity), B watched 30 days ago, A watched 10 days ago
-        # desc order: infinity > 30 > 10, so C, B, A
+        # C is unwatched - unwatched ALWAYS come first regardless of order
+        # desc order among watched: 30 > 10, so B before A
         assert titles == ["C", "B", "A"]
 
-    def test_last_watched_asc_watched_recently_first(self, plex_items_and_activity):
-        """Test that recently watched items come first with asc order."""
+    def test_last_watched_asc_unwatched_still_first(self, plex_items_and_activity):
+        """Test that unwatched items STILL come first even with asc order.
+
+        This is intentional behavior: unwatched items should be prioritized
+        for deletion before recently-watched items, regardless of order setting.
+        The order setting only affects how watched items are sorted among themselves.
+        """
         media_list, activity_data, plex_guid_item_pair = plex_items_and_activity
 
         sort_config = {"field": "last_watched", "order": "asc"}
         sorted_list = sort_media(media_list, sort_config, activity_data, plex_guid_item_pair)
         titles = [item["sortTitle"] for item in sorted_list]
 
-        # asc order: 10 < 30 < infinity, so A, B, C
-        assert titles == ["A", "B", "C"]
+        # C is unwatched - unwatched ALWAYS come first regardless of order
+        # asc order among watched: 10 < 30, so A before B
+        assert titles == ["C", "A", "B"]
 
     def test_last_watched_with_secondary_sort(self, plex_items_and_activity):
         """Test last_watched combined with secondary sort field."""


### PR DESCRIPTION
## Summary

- Eliminate N unnecessary `get_metadata` API calls by extracting data directly from `get_history` response
- Fix `last_watched` sort to always prioritize unwatched items for deletion

## Problem

The `get_history` endpoint already returns `guid`, `title`, `year`, and `grandparent_title`. The previous implementation was making N additional `get_metadata` API calls (one per unique item) when all required data was already available.

**Before:** `1 + N` API calls (1 paginated history + N metadata calls)
**After:** Just `1` API call per page

For a library with 500 items, this eliminates ~500 API calls.

## Changes

### Tautulli Module
- Remove `_fetch_metadata_parallel()` and `ThreadPoolExecutor` usage
- Extract guid/title/year directly from history response  
- Use `grandparent_title` for TV shows (series name vs episode name)

### Sort Fix
- Unwatched items now always come first when sorting by `last_watched`, regardless of `order` setting
- This ensures unwatched content is prioritized for deletion before recently-watched content

## Test plan

- [x] All unit tests pass (619 passed)
- [ ] Manual verification with DEBUG logging enabled