### PR TITLE
perf(tautulli): fetch all history instead of using date filter

### DIFF
--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -357,10 +357,10 @@ class MediaCleaner:
         return self.plex.library.section(library.get("name"))
 
     def get_show_activity(self, library, plex_library):
-        return self.tautulli.get_activity(library, plex_library.key)
+        return self.tautulli.get_activity(plex_library.key)
 
     def get_movie_activity(self, library, movies_library):
-        return self.tautulli.get_activity(library, movies_library.key)
+        return self.tautulli.get_activity(movies_library.key)
 
     def filter_shows(self, library, unfiltered_all_show_data):
         return [


### PR DESCRIPTION
## Summary

Simplifies Tautulli history retrieval by fetching all history instead of calculating a min_date based on thresholds.

**Why:** The previous approach required calculating dates from thresholds, which added complexity. Since threshold filtering happens downstream anyway (in `check_watched_status()`), we can fetch all history and let the existing logic handle filtering.

## Changes

- Remove `_calculate_min_date()` method
- Simplify `get_activity()` to only take `section` parameter  
- Remove `after` filter from `_fetch_history_data()`
- Update callers in `media_cleaner.py`

## Test plan

- [x] Unit tests pass
- [ ] Integration test with real Tautulli instance