### PR TITLE
fix(deleterr): handle death row movie deletion errors gracefully

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -353,16 +353,24 @@ class Deleterr:
             )
 
             if not is_dry_run:
-                if media_type == "movie":
-                    media_instance.del_movie(
-                        media_item["id"],
-                        delete_files=True,
-                        add_exclusion=library.get("add_list_exclusion_on_delete", False),
+                try:
+                    if media_type == "movie":
+                        media_instance.del_movie(
+                            media_item["id"],
+                            delete_files=True,
+                            add_exclusion=library.get("add_list_exclusion_on_delete", False),
+                        )
+                        self.media_cleaner._update_overseerr_status(library, media_item, "movie")
+                    else:
+                        self.media_cleaner.delete_series(media_instance, media_item)
+                        self.media_cleaner._update_overseerr_status(library, media_item, "tv")
+                except Exception as e:
+                    logger.error(
+                        f"Failed to delete '{media_item['title']}' from "
+                        f"{'Radarr' if media_type == 'movie' else 'Sonarr'}: {e}. "
+                        "Will retry on next run."
                     )
-                    self.media_cleaner._update_overseerr_status(library, media_item, "movie")
-                else:
-                    self.media_cleaner.delete_series(media_instance, media_item)
-                    self.media_cleaner._update_overseerr_status(library, media_item, "tv")
+                    continue
 
             deleted_items.append(media_item)
 


### PR DESCRIPTION
## Summary
- Wrap movie/show deletion in `_process_death_row` with try/except so a single API failure (network error, timeout, etc.) no longer breaks the entire deletion loop
- Failed items are logged with title and error details, skipped, and retried on the next run
- Failed items are not counted as deleted (stay in leaving_soon for retry)

## Test plan
- [x] `test_movie_deletion_failure_continues_to_next` - remaining movies processed after one fails
- [x] `test_movie_deletion_failure_not_in_deleted_items` - failed movie not counted as deleted
- [x] `test_movie_deletion_failure_logged` - error logged with movie title
- [x] `test_show_deletion_failure_continues` - same resilience for shows

Closes #227