### PR TITLE
docs: add guide pages for exclusions, integrations, sorting, and more

### DIFF
--- a/docs/features/disk-thresholds.md
+++ b/docs/features/disk-thresholds.md
@@ -1,0 +1,104 @@
+# Disk Thresholds
+
+Only delete media when disk space falls below a specified limit. This is useful if you only want Deleterr to clean up when you're actually running low on storage.
+
+## How It Works
+
+1. Deleterr queries the Radarr/Sonarr API for disk space information
+2. If free space on the configured path is **above** the threshold, the library is skipped entirely
+3. If free space is **below** the threshold, Deleterr proceeds with normal deletion logic
+
+## Configuration
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    disk_size_threshold:
+      - path: "/data/media"
+        threshold: "500GB"
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `path` | Path to check disk space for (must match a root folder in Radarr/Sonarr) |
+| `threshold` | Minimum free space. If free space is above this, the library is skipped |
+
+### Size Units
+
+Supported units: `B`, `KB`, `MB`, `GB`, `TB`, `PB`, `EB`
+
+```yaml
+threshold: "500GB"
+threshold: "1TB"
+threshold: "100MB"
+```
+
+## Path Gotcha
+
+!!! warning "Use the Container Path"
+    The `path` must be a path accessible to Radarr/Sonarr, not the host path. This is the root folder path as configured in Radarr/Sonarr settings.
+
+For example, if your Docker Compose maps `/mnt/storage/media` on the host to `/data/media` inside the Radarr container, use `/data/media`:
+
+```yaml
+disk_size_threshold:
+  - path: "/data/media"       # Radarr/Sonarr container path
+    threshold: "500GB"
+```
+
+If the path doesn't match any root folder in Radarr/Sonarr, Deleterr will raise a configuration error.
+
+## Multiple Paths
+
+You can specify multiple paths. All paths must be below their respective thresholds for deletion to proceed:
+
+```yaml
+disk_size_threshold:
+  - path: "/data/movies"
+    threshold: "200GB"
+  - path: "/data/tv"
+    threshold: "300GB"
+```
+
+## Combining with Sorting
+
+Disk thresholds work well with size-based sorting to maximize space reclaimed:
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    max_actions_per_run: 50
+    disk_size_threshold:
+      - path: "/data/media"
+        threshold: "500GB"
+    sort:
+      field: "size"
+      order: "desc"  # Delete largest files first
+```
+
+## Combining with Leaving Soon
+
+When combined with [Leaving Soon](leaving-soon.md), items are only tagged to the collection when disk space is low:
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    max_actions_per_run: 20
+    preview_next: 10
+    disk_size_threshold:
+      - path: "/data/media"
+        threshold: "500GB"
+    leaving_soon:
+      collection:
+        name: "Leaving Soon"
+```
+
+See [Configuration Reference](../CONFIGURATION.md) for the full field reference.

--- a/docs/features/exclusions.md
+++ b/docs/features/exclusions.md
@@ -1,0 +1,186 @@
+# Exclusions
+
+Exclusions protect media from deletion. If any exclusion rule matches an item, that item is skipped entirely -- exclusions use **OR logic**, so a single match is enough to protect it.
+
+## Quick Reference
+
+| Category | Exclusion Types |
+|----------|----------------|
+| **Metadata** | `titles`, `genres`, `collections`, `actors`, `directors`, `writers`, `producers`, `studios`, `plex_labels`, `release_years` |
+| **Radarr** | `tags`, `quality_profiles`, `paths`, `monitored` |
+| **Sonarr** | `status`, `tags`, `quality_profiles`, `paths`, `monitored` |
+| **Integrations** | [`trakt`](../integrations/trakt.md), [`mdblist`](../integrations/mdblist.md), [`justwatch`](../integrations/justwatch.md), [`overseerr`](../integrations/overseerr.md) |
+
+All exclusions are configured under the `exclude` key inside a library block:
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    exclude:
+      # Your exclusion rules here
+```
+
+---
+
+## Metadata Exclusions
+
+### Titles
+
+Exact title match (case-insensitive):
+
+```yaml
+exclude:
+  titles:
+    - "Forrest Gump"
+    - "The Godfather"
+```
+
+### Genres
+
+Match against Plex genre tags (case-insensitive):
+
+```yaml
+exclude:
+  genres:
+    - "documentary"
+    - "horror"
+```
+
+### Collections
+
+Match against Plex collection names (case-insensitive):
+
+```yaml
+exclude:
+  collections:
+    - "Marvel Cinematic Universe"
+    - "Star Wars Collection"
+```
+
+### Actors
+
+Match against Plex actor credits (case-insensitive):
+
+```yaml
+exclude:
+  actors:
+    - "Tom Hanks"
+    - "Brad Pitt"
+```
+
+### Directors
+
+```yaml
+exclude:
+  directors:
+    - "Christopher Nolan"
+    - "Denis Villeneuve"
+```
+
+### Writers
+
+```yaml
+exclude:
+  writers:
+    - "Aaron Sorkin"
+```
+
+### Producers
+
+```yaml
+exclude:
+  producers:
+    - "Steven Spielberg"
+```
+
+### Studios
+
+```yaml
+exclude:
+  studios:
+    - "Studio Ghibli"
+    - "A24"
+```
+
+### Plex Labels
+
+Protect items you've manually labeled in Plex:
+
+```yaml
+exclude:
+  plex_labels:
+    - "favorite"
+    - "keep"
+    - "classic"
+```
+
+!!! tip "Manual Override"
+    `plex_labels` is the easiest way to protect individual items. Add a "keep" label to any item in Plex and exclude that label in your config.
+
+### Release Years
+
+Protect media released within the last X years:
+
+```yaml
+exclude:
+  release_years: 2  # Keep anything released in the last 2 years
+```
+
+---
+
+## Radarr Exclusions
+
+These apply only to movie libraries backed by Radarr.
+
+```yaml
+exclude:
+  radarr:
+    tags: ["4K", "keep", "favorite"]         # Case-insensitive tag match
+    quality_profiles: ["Remux-2160p"]         # Exact profile name match
+    paths: ["/data/media/4k"]                 # Substring match against movie path
+    monitored: true                           # true = exclude monitored, false = exclude unmonitored
+```
+
+---
+
+## Sonarr Exclusions
+
+These apply only to TV show libraries backed by Sonarr.
+
+```yaml
+exclude:
+  sonarr:
+    status: ["continuing", "upcoming"]        # Series status: continuing, ended, upcoming, deleted
+    tags: ["4K", "keep"]                      # Case-insensitive tag match
+    quality_profiles: ["Bluray-2160p"]        # Exact profile name match
+    paths: ["/data/media/4k"]                 # Substring match against series path
+    monitored: true                           # true = exclude monitored, false = exclude unmonitored
+```
+
+---
+
+## Integration Exclusions
+
+Deleterr integrates with external services for more advanced exclusion logic:
+
+| Integration | What It Does | API Key Required? |
+|-------------|-------------|-------------------|
+| [Trakt](../integrations/trakt.md) | Protect media on Trakt lists (trending, popular, user lists) | Yes |
+| [MDBList](../integrations/mdblist.md) | Protect media on MDBList lists (aggregates IMDB, TMDB, Trakt, etc.) | Yes |
+| [JustWatch](../integrations/justwatch.md) | Protect based on streaming availability | No |
+| [Overseerr](../integrations/overseerr.md) | Protect or target media based on user requests | Yes |
+
+See each integration page for setup details and configuration options.
+
+---
+
+## Tips
+
+- **OR logic**: Any single exclusion match protects the item. You don't need an item to match all rules.
+- **Debug logging**: Set `LOG_LEVEL: DEBUG` to see exactly which exclusion rule is protecting each item.
+- **Plex labels as manual override**: The simplest way to protect a specific item is to add a label in Plex and exclude that label.
+- **Combine exclusions freely**: Metadata, Radarr/Sonarr, and integration exclusions all work together.
+
+See [Configuration Reference](../CONFIGURATION.md) for the full list of exclusion fields and their types. For ready-to-use patterns, see the [Common Exclusion Patterns](../templates.md#common-exclusion-patterns) section in Templates.

--- a/docs/features/leaving-soon.md
+++ b/docs/features/leaving-soon.md
@@ -131,7 +131,7 @@ Pin the "Leaving Soon" collection to your Plex home screen so users see it promi
 
 ### Combine with Disk Thresholds
 
-Leaving Soon works well with disk thresholds - items are only tagged when disk space is low:
+Leaving Soon works well with [disk thresholds](disk-thresholds.md) - items are only tagged when disk space is low:
 
 ```yaml
 libraries:

--- a/docs/features/multi-instance.md
+++ b/docs/features/multi-instance.md
@@ -1,0 +1,130 @@
+# Multi-Instance Support
+
+Deleterr supports multiple Radarr and Sonarr instances, allowing you to manage separate libraries (e.g., standard and 4K) with different retention policies.
+
+## Use Case
+
+A common setup has separate instances for different quality tiers:
+
+- **Standard Radarr/Sonarr** for 1080p content with aggressive cleanup
+- **4K Radarr/Sonarr** for 2160p content with conservative cleanup
+
+Each instance can have different deletion thresholds, exclusions, and limits.
+
+## Setup
+
+### 1. Define Named Instances
+
+List your Radarr and/or Sonarr instances at the top level. Each instance needs a unique `name`:
+
+```yaml
+radarr:
+  - name: "Radarr"
+    url: "http://localhost:7878"
+    api_key: "YOUR_RADARR_API_KEY"
+  - name: "Radarr 4K"
+    url: "http://localhost:7879"
+    api_key: "YOUR_RADARR_4K_API_KEY"
+
+sonarr:
+  - name: "Sonarr"
+    url: "http://localhost:8989"
+    api_key: "YOUR_SONARR_API_KEY"
+  - name: "Sonarr 4K"
+    url: "http://localhost:8990"
+    api_key: "YOUR_SONARR_4K_API_KEY"
+```
+
+### 2. Reference Instances in Library Blocks
+
+Each library block references an instance by name:
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"         # References the instance named "Radarr"
+    action_mode: "delete"
+    # ...
+
+  - name: "Movies 4K"
+    radarr: "Radarr 4K"      # References the instance named "Radarr 4K"
+    action_mode: "delete"
+    # ...
+```
+
+!!! note
+    The library `name` must match the exact Plex library name. The `radarr`/`sonarr` value must match an instance `name` defined above.
+
+## Full Example
+
+```yaml
+dry_run: true
+
+plex:
+  url: "http://localhost:32400"
+  token: "YOUR_PLEX_TOKEN"
+
+tautulli:
+  url: "http://localhost:8181"
+  api_key: "YOUR_TAUTULLI_API_KEY"
+
+radarr:
+  - name: "Radarr"
+    url: "http://localhost:7878"
+    api_key: "YOUR_RADARR_API_KEY"
+  - name: "Radarr 4K"
+    url: "http://localhost:7879"
+    api_key: "YOUR_RADARR_4K_API_KEY"
+
+sonarr:
+  - name: "Sonarr"
+    url: "http://localhost:8989"
+    api_key: "YOUR_SONARR_API_KEY"
+  - name: "Sonarr 4K"
+    url: "http://localhost:8990"
+    api_key: "YOUR_SONARR_4K_API_KEY"
+
+libraries:
+  # Standard quality - more aggressive cleanup
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    last_watched_threshold: 60
+    added_at_threshold: 90
+    max_actions_per_run: 50
+
+  # 4K - conservative cleanup
+  - name: "Movies 4K"
+    radarr: "Radarr 4K"
+    action_mode: "delete"
+    last_watched_threshold: 180
+    added_at_threshold: 365
+    max_actions_per_run: 10
+    exclude:
+      radarr:
+        tags: ["keep", "favorite"]
+
+  - name: "TV Shows"
+    sonarr: "Sonarr"
+    series_type: "standard"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+
+  - name: "TV Shows 4K"
+    sonarr: "Sonarr 4K"
+    series_type: "standard"
+    action_mode: "delete"
+    last_watched_threshold: 365
+    added_at_threshold: 365
+    max_actions_per_run: 5
+```
+
+## Tips
+
+- **Different thresholds per tier**: 4K content is harder to re-download, so use longer thresholds and lower `max_actions_per_run`.
+- **Instance-specific exclusions**: Use Radarr/Sonarr tag exclusions per instance to protect specific content in one instance but not the other.
+- **Disk thresholds per path**: If 4K and standard content are on separate drives, use [disk thresholds](disk-thresholds.md) with different paths.
+
+See the [4K Multi-Instance template](../templates.md#2-4k-multi-instance) for a ready-to-use configuration. See [Configuration Reference](../CONFIGURATION.md) for the full field reference.

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -238,7 +238,7 @@ The default leaving soon template includes:
 - Tip explaining how watching content keeps it
 - Grouped sections for Movies and TV Shows
 - Links to Plex (if configured)
-- Links to Overseerr for re-requesting (if configured)
+- Links to [Overseerr](../integrations/overseerr.md) for re-requesting (if configured)
 
 ### Custom Templates
 

--- a/docs/features/sorting.md
+++ b/docs/features/sorting.md
@@ -1,0 +1,112 @@
+# Sorting & Prioritization
+
+Sorting controls which items get deleted first when `max_actions_per_run` limits the number of deletions per run. Without sorting, deletion order is undefined.
+
+## Why Sorting Matters
+
+If your library has 100 items eligible for deletion but `max_actions_per_run: 10`, sorting determines which 10 get deleted. You might want to delete the largest files first to reclaim the most space, or the lowest-rated content first to keep better media longer.
+
+## Configuration
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    max_actions_per_run: 20
+    sort:
+      field: "size"
+      order: "desc"  # Largest first
+```
+
+## Sort Fields
+
+| Field | Description | Applies To |
+|-------|-------------|------------|
+| `title` | Alphabetical by sort title | Movies, TV Shows |
+| `size` | File size on disk | Movies, TV Shows |
+| `release_year` | Year of release | Movies, TV Shows |
+| `runtime` | Duration in minutes | Movies |
+| `added_date` | Date added to Radarr/Sonarr | Movies, TV Shows |
+| `rating` | IMDB or TMDB rating | Movies, TV Shows |
+| `seasons` | Number of seasons | TV Shows |
+| `episodes` | Total episode count | TV Shows |
+| `last_watched` | Days since last watch | Movies, TV Shows |
+
+## Multi-Level Sorting
+
+Sort by multiple fields using comma-separated values. The first field is the primary sort; ties are broken by subsequent fields.
+
+```yaml
+sort:
+  field: "last_watched,size"
+  order: "desc,desc"
+```
+
+If fewer orders than fields are provided, the last order is reused:
+
+```yaml
+sort:
+  field: "last_watched,size,title"
+  order: "desc"  # All three fields sort descending
+```
+
+## last_watched Special Behavior
+
+When sorting by `last_watched`, **unwatched items always sort first** regardless of the order setting. The `order` only affects how watched items are sorted among themselves.
+
+This ensures unwatched content is prioritized for deletion before recently-watched content -- the logic being that if nobody has ever watched it, it's a better candidate for removal than something someone watched recently.
+
+## Common Strategies
+
+### Largest Files First
+
+Reclaim the most disk space per deletion:
+
+```yaml
+sort:
+  field: "size"
+  order: "desc"
+```
+
+### Oldest Content First
+
+Delete media that was released longest ago:
+
+```yaml
+sort:
+  field: "release_year"
+  order: "asc"
+```
+
+### Lowest Rated First
+
+Keep the best-rated content longest:
+
+```yaml
+sort:
+  field: "rating"
+  order: "asc"
+```
+
+### Unwatched + Largest First
+
+Prioritize unwatched content, then largest files among those:
+
+```yaml
+sort:
+  field: "last_watched,size"
+  order: "desc,desc"
+```
+
+### TV Shows by Episode Count
+
+Delete shows with the most episodes first (reclaim space from long-running series):
+
+```yaml
+sort:
+  field: "episodes"
+  order: "desc"
+```
+
+See [Configuration Reference](../CONFIGURATION.md) for the full field reference.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,8 @@ Deleterr identifies and deletes media files based on user-specified criteria. Se
 - [Getting Started](getting-started.md) - Docker setup and first run
 - [Configuration Reference](CONFIGURATION.md) - All settings explained
 - [Templates](templates.md) - Copy-paste ready configurations
+- [Exclusions](features/exclusions.md) - Protect content from deletion
+- [Integrations](integrations/trakt.md) - Trakt, MDBList, JustWatch, Overseerr
 
 ---
 
@@ -56,15 +58,21 @@ Alert your users via Email, Discord, Slack, or Telegram about content that's exp
 
 ### Smart Exclusions
 
-Protect content by genre, actor, Plex labels, streaming availability (JustWatch), Trakt lists, and more.
+Protect content by genre, actor, Plex labels, streaming availability (JustWatch), Trakt lists, MDBList lists, and more.
+
+[Learn more about Exclusions](features/exclusions.md)
 
 ### Multi-Instance Support
 
 Configure multiple Radarr/Sonarr instances (e.g., separate 4K libraries) with different retention policies.
 
+[Learn more about Multi-Instance Support](features/multi-instance.md)
+
 ### Disk Thresholds
 
 Only delete when disk space falls below a specified limit - perfect for space-constrained systems.
+
+[Learn more about Disk Thresholds](features/disk-thresholds.md)
 
 ---
 

--- a/docs/integrations/justwatch.md
+++ b/docs/integrations/justwatch.md
@@ -1,0 +1,131 @@
+# JustWatch
+
+Protect or target media based on streaming availability using [JustWatch](https://www.justwatch.com/). No API key required -- Deleterr queries JustWatch's public API directly.
+
+## How It Works
+
+JustWatch checks whether a title is currently available on streaming services in your country. You can use this to:
+
+- **Keep content that's not streaming anywhere** (you can only watch it locally)
+- **Delete content that's available on your streaming subscriptions** (why store it locally?)
+
+## Setup
+
+### 1. Add global JustWatch settings
+
+```yaml
+justwatch:
+  country: "US"
+  language: "en"
+```
+
+The `country` field uses [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes (e.g., `US`, `GB`, `DE`, `FR`, `AU`).
+
+### 2. Add JustWatch exclusions to your library
+
+JustWatch offers two mutually exclusive modes -- you must pick one per library:
+
+=== "available_on (exclude if streaming)"
+
+    Protect media that is available on specified providers. Items available on these services won't be deleted.
+
+    ```yaml
+    exclude:
+      justwatch:
+        available_on: ["netflix", "disneyplus", "amazon"]
+    ```
+
+    **Use case**: "Don't delete movies I can rewatch on Netflix."
+
+=== "not_available_on (exclude if NOT streaming)"
+
+    Protect media that is NOT available on specified providers. Items that can't be streamed won't be deleted.
+
+    ```yaml
+    exclude:
+      justwatch:
+        not_available_on: ["any"]
+    ```
+
+    **Use case**: "Keep movies that aren't on any streaming service -- I can only watch them locally."
+
+!!! warning "Mutually Exclusive"
+    You cannot use `available_on` and `not_available_on` in the same library. Pick the mode that matches your intent.
+
+## Common Provider Names
+
+| Provider | Technical Name |
+|----------|---------------|
+| Netflix | `netflix` |
+| Amazon Prime Video | `amazon` |
+| Disney+ | `disneyplus` |
+| HBO Max | `hbomax` |
+| Hulu | `hulu` |
+| Apple TV+ | `apple` |
+| Paramount+ | `paramount` |
+| Peacock | `peacock` |
+| *Any service* | `any` |
+
+Use `any` as a special value to match any streaming provider.
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `country` | Global setting | Override the global country code for this library |
+| `language` | Global setting | Override the global language for this library |
+| `available_on` | - | Exclude media available on these providers |
+| `not_available_on` | - | Exclude media NOT available on these providers |
+
+## Title Matching
+
+JustWatch searches by title and matches results using:
+
+1. Exact title + exact year
+2. Case-insensitive title + exact year
+3. Case-insensitive title + 1-year tolerance (release dates vary by region)
+
+If no match is found, the item is not excluded (JustWatch has no opinion on it).
+
+## Rate Limiting
+
+JustWatch may return HTTP 429 (Too Many Requests) if you process many items quickly. When this happens:
+
+- Deleterr logs a warning on the first occurrence
+- Subsequent rate-limited items are silently skipped
+- The rate limit resets automatically
+
+If you frequently hit rate limits, consider reducing `max_actions_per_run` or running less frequently.
+
+## Full Example
+
+```yaml
+justwatch:
+  country: "US"
+  language: "en"
+
+libraries:
+  # Main library: keep movies not available anywhere
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+    exclude:
+      justwatch:
+        not_available_on: ["any"]
+
+  # Streaming copies: more aggressive for content on your services
+  - name: "Streaming Copies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    last_watched_threshold: 30
+    added_at_threshold: 90
+    max_actions_per_run: 50
+    exclude:
+      justwatch:
+        available_on: ["netflix", "disneyplus", "amazon", "hbomax", "hulu"]
+```
+
+See [Configuration Reference](../CONFIGURATION.md) for the full field reference.

--- a/docs/integrations/mdblist.md
+++ b/docs/integrations/mdblist.md
@@ -1,0 +1,96 @@
+# MDBList
+
+Protect media that appears on [MDBList](https://mdblist.com/) lists. MDBList aggregates lists from IMDB, TMDB, Trakt, Letterboxd, and more into a single platform -- so you can reuse the same lists you already use for Radarr/Sonarr imports as exclusion rules.
+
+## Prerequisites
+
+1. Create an account at [mdblist.com](https://mdblist.com/)
+2. Get your API key from [mdblist.com/preferences/](https://mdblist.com/preferences/)
+
+## Setup
+
+### 1. Add global MDBList credentials
+
+```yaml
+mdblist:
+  api_key: "YOUR_MDBLIST_API_KEY"
+```
+
+### 2. Add MDBList exclusions to your library
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    exclude:
+      mdblist:
+        lists:
+          - "https://mdblist.com/lists/linaspuransen/top-250-movies"
+          - "https://mdblist.com/lists/username/my-custom-list"
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `max_items_per_list` | `1000` | Maximum items to fetch from each list |
+| `lists` | `[]` | List of MDBList URLs to exclude |
+
+## URL Format
+
+MDBList list URLs follow the pattern:
+
+```
+https://mdblist.com/lists/<username>/<listname>
+```
+
+You can find the URL by navigating to any list on mdblist.com and copying the URL from your browser.
+
+## How Matching Works
+
+- **Movies** are matched by TMDB ID
+- **TV Shows** are matched by TVDB ID
+
+Items are fetched in pages of 1000 and capped at `max_items_per_list`. If a list has more items than the limit, only the first N items are checked.
+
+## Full Example
+
+```yaml
+mdblist:
+  api_key: "YOUR_MDBLIST_API_KEY"
+
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+    exclude:
+      mdblist:
+        max_items_per_list: 2000
+        lists:
+          - "https://mdblist.com/lists/linaspuransen/top-250-movies"
+          - "https://mdblist.com/lists/hdlists/top-ten-pirated-movies-of-the-week"
+
+  - name: "TV Shows"
+    sonarr: "Sonarr"
+    series_type: "standard"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+    exclude:
+      mdblist:
+        lists:
+          - "https://mdblist.com/lists/garycrawfordgc/top-rated-tv"
+```
+
+## Tips
+
+- MDBList is a good alternative to Trakt if you already use MDBList lists to manage your Radarr/Sonarr imports.
+- Set `max_items_per_list` higher (e.g., `2000`) for large curated lists.
+- Enable `LOG_LEVEL: DEBUG` to confirm which items are being matched against your lists.
+
+See [Configuration Reference](../CONFIGURATION.md) for the full field reference.

--- a/docs/integrations/overseerr.md
+++ b/docs/integrations/overseerr.md
@@ -1,0 +1,170 @@
+# Overseerr / Seerr
+
+Integrate with [Overseerr](https://overseerr.dev/) to make deletion decisions based on user requests. Deleterr supports two capabilities:
+
+1. **Exclude or target media** based on whether it was requested through Overseerr
+2. **Mark deleted media** in Overseerr so users can request it again
+
+!!! note "Seerr Compatibility"
+    Deleterr works with both Overseerr and [Seerr](https://github.com/jorenn92/maintainerr) -- they share the same API. Use the same configuration for either.
+
+## Prerequisites
+
+1. A running Overseerr (or Seerr) instance
+2. API key from Overseerr Settings > General
+
+## Setup
+
+### 1. Add global Overseerr connection
+
+```yaml
+overseerr:
+  url: "http://localhost:5055"
+  api_key: "YOUR_OVERSEERR_API_KEY"
+```
+
+### 2. Add Overseerr exclusions to your library
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    exclude:
+      overseerr:
+        mode: "exclude"
+```
+
+## Modes
+
+### Exclude Mode (default)
+
+Protects requested media from deletion. Use this when you want to keep content that users asked for.
+
+```yaml
+exclude:
+  overseerr:
+    mode: "exclude"
+```
+
+**Use case**: "Don't delete movies that someone specifically requested."
+
+### Include-Only Mode
+
+Only deletes media that was requested through Overseerr. Everything else is skipped.
+
+```yaml
+exclude:
+  overseerr:
+    mode: "include_only"
+```
+
+**Use case**: "Only clean up content that came in through Overseerr -- leave manually added content alone."
+
+## Filtering Options
+
+### Filter by User
+
+Only consider requests from specific users (matched by username, email, or Plex username):
+
+```yaml
+exclude:
+  overseerr:
+    mode: "exclude"
+    users: ["admin", "family-member"]
+```
+
+### Filter by Request Status
+
+Only consider requests with specific statuses (`pending`, `approved`, `declined`):
+
+```yaml
+exclude:
+  overseerr:
+    mode: "exclude"
+    request_status: ["approved"]
+```
+
+### Include Pending Requests
+
+Control whether pending (not yet approved) requests count:
+
+```yaml
+exclude:
+  overseerr:
+    mode: "exclude"
+    include_pending: false  # Only protect approved requests
+```
+
+### Minimum Request Age
+
+Only consider requests older than a certain number of days. This gives users a window to watch before the protection expires:
+
+```yaml
+exclude:
+  overseerr:
+    mode: "exclude"
+    min_request_age_days: 30  # Requests older than 30 days can be deleted
+```
+
+## Post-Deletion: Update Status
+
+When `update_status` is enabled, Deleterr marks deleted media in Overseerr so it can be requested again:
+
+```yaml
+exclude:
+  overseerr:
+    mode: "exclude"
+    update_status: true
+```
+
+Without this, deleted media still shows as "available" in Overseerr and users can't re-request it.
+
+## Full Example
+
+```yaml
+overseerr:
+  url: "http://localhost:5055"
+  api_key: "YOUR_OVERSEERR_API_KEY"
+
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+    exclude:
+      overseerr:
+        mode: "exclude"
+        include_pending: true
+        request_status: ["approved", "pending"]
+        update_status: true
+
+  - name: "TV Shows"
+    sonarr: "Sonarr"
+    series_type: "standard"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+    exclude:
+      overseerr:
+        mode: "exclude"
+        users: ["admin"]
+        min_request_age_days: 60
+        update_status: true
+```
+
+## Configuration Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `mode` | `"exclude"` | `exclude` protects requested items; `include_only` deletes only requested items |
+| `users` | `[]` | Filter by username, email, or Plex username. Empty = all users |
+| `include_pending` | `true` | Whether pending requests count |
+| `request_status` | `[]` | Filter by status: `pending`, `approved`, `declined`. Empty = all |
+| `min_request_age_days` | `0` | Only consider requests older than this many days |
+| `update_status` | `false` | Mark deleted media in Overseerr so it can be re-requested |
+
+See [Configuration Reference](../CONFIGURATION.md) for the full field reference.

--- a/docs/integrations/trakt.md
+++ b/docs/integrations/trakt.md
@@ -1,0 +1,129 @@
+# Trakt
+
+Protect media that appears on [Trakt](https://trakt.tv/) lists. Keep trending, popular, and personally curated content safe from deletion.
+
+## Prerequisites
+
+1. Create a Trakt API application at [trakt.tv/oauth/applications](https://trakt.tv/oauth/applications)
+2. Note the **Client ID** and **Client Secret**
+
+## Setup
+
+### 1. Add global Trakt credentials
+
+```yaml
+trakt:
+  client_id: "YOUR_TRAKT_CLIENT_ID"
+  client_secret: "YOUR_TRAKT_CLIENT_SECRET"
+```
+
+### 2. Add Trakt exclusions to your library
+
+```yaml
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    exclude:
+      trakt:
+        lists:
+          - "https://trakt.tv/movies/trending"
+          - "https://trakt.tv/movies/popular"
+```
+
+## Supported List Types
+
+### Official Lists
+
+Curated by Trakt based on community activity:
+
+```yaml
+exclude:
+  trakt:
+    lists:
+      - "https://trakt.tv/movies/trending"
+      - "https://trakt.tv/movies/popular"
+      - "https://trakt.tv/movies/anticipated"
+      - "https://trakt.tv/movies/boxoffice"
+      - "https://trakt.tv/shows/trending"
+      - "https://trakt.tv/shows/popular"
+      - "https://trakt.tv/shows/anticipated"
+```
+
+### User Watchlists
+
+A user's personal watchlist:
+
+```yaml
+exclude:
+  trakt:
+    lists:
+      - "https://trakt.tv/users/yourusername/watchlist"
+```
+
+### Custom User Lists
+
+Any public user list:
+
+```yaml
+exclude:
+  trakt:
+    lists:
+      - "https://trakt.tv/users/justin/lists/imdb-top-rated-movies"
+      - "https://trakt.tv/users/lwerndly/lists/anime-best-series-of-all-time"
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `max_items_per_list` | `100` | Maximum items to fetch from each list |
+| `lists` | `[]` | List of Trakt URLs to exclude |
+
+## How Matching Works
+
+- **Movies** are matched by TMDB ID
+- **TV Shows** are matched by TVDB ID
+
+## Known Limitations
+
+- **Favorites lists** (`https://trakt.tv/users/.../favorites`) are not supported by the underlying Trakt library. Use custom lists as an alternative.
+- **Periodic lists** (e.g., `watched/weekly`, `collected/monthly`) are not currently supported.
+
+## Full Example
+
+```yaml
+trakt:
+  client_id: "YOUR_TRAKT_CLIENT_ID"
+  client_secret: "YOUR_TRAKT_CLIENT_SECRET"
+
+libraries:
+  - name: "Movies"
+    radarr: "Radarr"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+    exclude:
+      trakt:
+        max_items_per_list: 200
+        lists:
+          - "https://trakt.tv/movies/trending"
+          - "https://trakt.tv/movies/popular"
+          - "https://trakt.tv/users/justin/lists/imdb-top-rated-movies"
+
+  - name: "TV Shows"
+    sonarr: "Sonarr"
+    series_type: "standard"
+    action_mode: "delete"
+    last_watched_threshold: 90
+    added_at_threshold: 180
+    max_actions_per_run: 20
+    exclude:
+      trakt:
+        lists:
+          - "https://trakt.tv/shows/trending"
+          - "https://trakt.tv/shows/popular"
+```
+
+See [Configuration Reference](../CONFIGURATION.md) for the full field reference.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -538,3 +538,14 @@ libraries:
 
 - [Configuration Reference](CONFIGURATION.md) - Detailed documentation of all options
 - [Getting Started](getting-started.md) - Installation and setup guide
+- [Exclusions](features/exclusions.md) - Understand how exclusion rules work
+- [Sorting & Prioritization](features/sorting.md) - Control deletion order
+- [Disk Thresholds](features/disk-thresholds.md) - Only delete when disk space is low
+- [Multi-Instance Support](features/multi-instance.md) - Manage 4K and standard libraries separately
+
+### Integration Guides
+
+- [Trakt](integrations/trakt.md) - Protect media on Trakt lists
+- [MDBList](integrations/mdblist.md) - Protect media on MDBList lists
+- [JustWatch](integrations/justwatch.md) - Streaming availability exclusions
+- [Overseerr / Seerr](integrations/overseerr.md) - Request-based exclusions

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -258,6 +258,92 @@ See [Notifications Troubleshooting](features/notifications.md#troubleshooting) f
      - /var/run/docker.sock:/var/run/docker.sock:ro
    ```
 
+## JustWatch Issues
+
+### Streaming Check Not Working
+
+**Symptoms**: Items aren't being excluded even though they're on Netflix/etc.
+
+**Solutions**:
+
+1. **Check country code**: Must match your streaming region
+   ```yaml
+   justwatch:
+     country: "US"  # ISO 3166-1 alpha-2 code
+   ```
+
+2. **Title matching**: JustWatch searches by title -- unusual characters or regional titles may not match. Enable `LOG_LEVEL: DEBUG` to see search results.
+
+3. **Rate limiting**: If you see `JustWatch API rate limit hit` in logs, reduce `max_actions_per_run` or run less frequently.
+
+See [JustWatch Integration](integrations/justwatch.md) for full setup details.
+
+## Overseerr Issues
+
+### Overseerr Connection Failed
+
+**Symptoms**: `Cannot reach Overseerr` or `API authentication failed`
+
+**Solutions**:
+
+1. **Check URL and API key**:
+   ```yaml
+   overseerr:
+     url: "http://localhost:5055"
+     api_key: "YOUR_API_KEY"  # From Overseerr Settings > General
+   ```
+
+2. **Test connection**:
+   ```bash
+   curl -H "X-Api-Key: YOUR_KEY" http://overseerr:5055/api/v1/status
+   ```
+
+3. **Seerr users**: The same configuration works for Seerr -- no changes needed.
+
+### Deleted Media Still Shows as Available
+
+If deleted media still shows "available" in Overseerr, enable `update_status`:
+
+```yaml
+exclude:
+  overseerr:
+    update_status: true
+```
+
+See [Overseerr Integration](integrations/overseerr.md) for full setup details.
+
+## Trakt / MDBList Issues
+
+### List Items Not Being Excluded
+
+**Symptoms**: Items on Trakt/MDBList lists are still being deleted
+
+**Solutions**:
+
+1. **Verify credentials**: Ensure `trakt.client_id`/`client_secret` or `mdblist.api_key` are correct
+
+2. **Check list URL format**: URLs must match supported patterns
+   ```yaml
+   # Trakt
+   - "https://trakt.tv/movies/trending"
+   - "https://trakt.tv/users/username/lists/listname"
+
+   # MDBList
+   - "https://mdblist.com/lists/username/listname"
+   ```
+
+3. **Increase max_items_per_list**: If your list has more items than the default limit
+   ```yaml
+   trakt:
+     max_items_per_list: 200   # Default: 100
+   mdblist:
+     max_items_per_list: 2000  # Default: 1000
+   ```
+
+4. **Check matching IDs**: Trakt matches by TMDB/TVDB ID. If an item lacks these IDs, it won't match.
+
+See [Trakt Integration](integrations/trakt.md) and [MDBList Integration](integrations/mdblist.md) for full setup details.
+
 ## Getting Help
 
 If you're still stuck:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,10 +52,19 @@ nav:
   - Home: index.md
   - Getting Started:
     - Installation: getting-started.md
-    - Configuration: CONFIGURATION.md
-    - Templates: templates.md
+    - Configuration Reference: CONFIGURATION.md
+  - Templates: templates.md
   - Features:
     - Leaving Soon: features/leaving-soon.md
     - Notifications: features/notifications.md
+    - Exclusions: features/exclusions.md
+    - Sorting & Prioritization: features/sorting.md
+    - Disk Thresholds: features/disk-thresholds.md
+    - Multi-Instance Support: features/multi-instance.md
+  - Integrations:
+    - Trakt: integrations/trakt.md
+    - MDBList: integrations/mdblist.md
+    - JustWatch: integrations/justwatch.md
+    - Overseerr / Seerr: integrations/overseerr.md
   - Operations:
     - Troubleshooting: troubleshooting.md


### PR DESCRIPTION
## Summary

- Add 8 new documentation pages for features and integrations that only existed in the auto-generated config reference
- Restructure mkdocs nav: new Integrations section, Templates promoted to top-level, Features expanded
- Add cross-links between existing and new pages
- Add troubleshooting sections for JustWatch, Overseerr, Trakt, and MDBList

## New pages

| Page | Coverage |
|------|----------|
| `features/exclusions.md` | All 20+ exclusion types, OR logic, metadata/Radarr/Sonarr/integration exclusions |
| `features/sorting.md` | 9 sort fields, multi-level sorting, `last_watched` special behavior |
| `features/disk-thresholds.md` | Path gotcha, size units, combining with sorting and leaving soon |
| `features/multi-instance.md` | 4K/standard setup with different retention policies |
| `integrations/mdblist.md` | Setup, URL format, TMDB/TVDB matching, `max_items_per_list` |
| `integrations/trakt.md` | Official lists, user watchlists, custom lists, known limitations |
| `integrations/justwatch.md` | `available_on` vs `not_available_on`, provider names, rate limiting |
| `integrations/overseerr.md` | `exclude`/`include_only` modes, filtering, `update_status`, Seerr compat |

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally)
- [ ] All nav links resolve
- [ ] Cross-links between pages work
- [ ] CONFIGURATION.md not modified