### PR TITLE
fix(leaving-soon): preserve collection items across shared library entries

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -358,7 +358,7 @@ class Deleterr:
                     "death row will be cleared (no deletions needed)",
                     library_name,
                 )
-            return 0, [], [], [], []
+            return 0, [], [], [], [], []
 
         library_name = library.get("name", "Unknown")
 
@@ -377,7 +377,7 @@ class Deleterr:
             plex_library = self.media_server.get_library(library_name)
         except Exception as e:
             logger.error(f"Failed to get Plex library '{library_name}': {e}")
-            return 0, [], [], [], []
+            return 0, [], [], [], [], []
 
         # Get death row items (items tagged on previous run)
         all_death_row_plex_items = self._get_death_row_items(library, plex_library)
@@ -408,7 +408,7 @@ class Deleterr:
                 len(all_death_row_plex_items),
                 library_name,
             )
-            return 0, [], None, [], all_death_row_plex_items
+            return 0, [], None, [], all_death_row_plex_items, []
 
         death_row_keys = {item.ratingKey for item in death_row_plex_items}
 
@@ -417,31 +417,32 @@ class Deleterr:
             library, media_instance, plex_library, media_type, all_data
         )
 
+        # Build a map of Plex ratingKey -> media item for all deletion candidates.
+        # This is needed both to find items to delete AND to identify which death row
+        # items belong to this library entry vs other entries sharing the same collection.
+        candidate_by_plex_key = {}
+        for media_item in all_deletion_candidates:
+            if media_type == "movie":
+                plex_item = self.media_server.find_item(
+                    plex_library,
+                    tmdb_id=media_item.get("tmdbId"),
+                    imdb_id=media_item.get("imdbId"),
+                    title=media_item.get("title"),
+                    year=media_item.get("year"),
+                )
+            else:
+                plex_item = self.media_server.find_item(
+                    plex_library,
+                    tvdb_id=media_item.get("tvdbId"),
+                    imdb_id=media_item.get("imdbId"),
+                    title=media_item.get("title"),
+                )
+            if plex_item:
+                candidate_by_plex_key[plex_item.ratingKey] = media_item
+
         # Items to delete = intersection of death row AND current candidates
-        # Only build the Plex lookup map if there are death row items to check
         items_to_delete = []
         if death_row_keys:
-            # Build a map of Plex ratingKey -> media item for candidates
-            candidate_by_plex_key = {}
-            for media_item in all_deletion_candidates:
-                if media_type == "movie":
-                    plex_item = self.media_server.find_item(
-                        plex_library,
-                        tmdb_id=media_item.get("tmdbId"),
-                        imdb_id=media_item.get("imdbId"),
-                        title=media_item.get("title"),
-                        year=media_item.get("year"),
-                    )
-                else:
-                    plex_item = self.media_server.find_item(
-                        plex_library,
-                        tvdb_id=media_item.get("tvdbId"),
-                        imdb_id=media_item.get("imdbId"),
-                        title=media_item.get("title"),
-                    )
-                if plex_item:
-                    candidate_by_plex_key[plex_item.ratingKey] = media_item
-
             for plex_key in death_row_keys:
                 if plex_key in candidate_by_plex_key:
                     items_to_delete.append(candidate_by_plex_key[plex_key])
@@ -451,20 +452,25 @@ class Deleterr:
         saved_plex_items = []
         is_dry_run = self.config.settings.get("dry_run", True)
 
+        # Log death row status and identify saved items.
+        # An item is "saved" if it's on death row, has a state entry (was tagged by this
+        # library name), but is NOT being deleted. This correctly identifies items that were
+        # previously eligible but are now protected (watched, excluded, etc.), even when
+        # multiple library entries share the same Plex library/collection name.
         if death_row_plex_items:
-            filtered_out = len(death_row_plex_items) - len(items_to_delete)
+            tagged_dates = self.state_manager.get_tagged_dates(library_name)
+            delete_keys = {k for k in candidate_by_plex_key if candidate_by_plex_key[k] in items_to_delete}
+            for plex_item in death_row_plex_items:
+                key = str(plex_item.ratingKey)
+                if key in tagged_dates and plex_item.ratingKey not in delete_keys:
+                    saved_plex_items.append(plex_item)
+
+            unmatched_count = len(death_row_plex_items) - len(items_to_delete)
             logger.info(
                 f"Found {len(death_row_plex_items)} items in leaving_soon, "
                 f"{len(items_to_delete)} still match deletion criteria"
-                + (f" ({filtered_out} protected by thresholds, exclusions, or watch activity since tagging)" if filtered_out > 0 else "")
+                + (f" ({unmatched_count} protected by thresholds, exclusions, or watch activity since tagging)" if unmatched_count > 0 else "")
             )
-            # Items "saved" from death row: they were on death row (eligible for deletion)
-            # but no longer match deletion criteria (watched, excluded, etc.)
-            if filtered_out > 0:
-                delete_keys = {k for k in candidate_by_plex_key if candidate_by_plex_key[k] in items_to_delete}
-                for plex_item in death_row_plex_items:
-                    if plex_item.ratingKey not in delete_keys:
-                        saved_plex_items.append(plex_item)
         else:
             logger.info("No items in leaving_soon (first run or empty death row)")
 
@@ -536,43 +542,47 @@ class Deleterr:
 
         deleted_ids = {m.get("id") for m in deleted_items}
 
-        # Get media items for duration-waiting Plex items (they need to stay in collection)
+        # Get media items for duration-waiting Plex items (they need to stay in collection).
+        # Items waiting but NOT in this entry's candidates are "foreign" - tagged by another
+        # library entry sharing the same Plex library/collection. These are preserved as raw
+        # Plex items since we can't look up their Radarr/Sonarr data.
         waiting_media_items = []
+        foreign_plex_items = []
         if duration_waiting_items:
-            # Build candidate_by_plex_key if not already built
-            if not death_row_keys:
-                candidate_by_plex_key = {}
-                for media_item in all_deletion_candidates:
-                    if media_type == "movie":
-                        plex_item = self.media_server.find_item(
-                            plex_library,
-                            tmdb_id=media_item.get("tmdbId"),
-                            imdb_id=media_item.get("imdbId"),
-                            title=media_item.get("title"),
-                            year=media_item.get("year"),
-                        )
-                    else:
-                        plex_item = self.media_server.find_item(
-                            plex_library,
-                            tvdb_id=media_item.get("tvdbId"),
-                            imdb_id=media_item.get("imdbId"),
-                            title=media_item.get("title"),
-                        )
-                    if plex_item:
-                        candidate_by_plex_key[plex_item.ratingKey] = media_item
-
             waiting_keys = {item.ratingKey for item in duration_waiting_items}
             waiting_media_items = [
                 candidate_by_plex_key[key]
                 for key in waiting_keys
                 if key in candidate_by_plex_key
             ]
+            # Foreign waiting items: in collection but not this entry's candidates
+            foreign_plex_items = [
+                item for item in duration_waiting_items
+                if item.ratingKey not in candidate_by_plex_key
+            ]
 
-        # When duration is configured and items are still on death row (waiting or just deleted),
-        # don't add new candidates. This ensures the current batch is fully processed before
-        # a new batch enters the collection. New candidates are only added when death row is empty.
-        if duration_str and all_death_row_plex_items:
-            # Death row has items - only keep the waiting ones, no new additions
+        # Also preserve eligible items from other entries (their duration may differ)
+        foreign_eligible = [
+            item for item in death_row_plex_items
+            if item.ratingKey not in candidate_by_plex_key
+        ]
+        foreign_plex_items.extend(foreign_eligible)
+
+        if foreign_plex_items:
+            logger.debug(
+                "Preserving %d items in collection from other library entries sharing '%s'",
+                len(foreign_plex_items),
+                library_name,
+            )
+
+        # When duration is configured and this entry has items on death row (waiting or just
+        # deleted), don't add new candidates. This ensures the current batch is fully processed
+        # before a new batch enters. Only check own items - foreign items don't block new batches.
+        own_in_death_row = any(
+            item.ratingKey in candidate_by_plex_key for item in all_death_row_plex_items
+        )
+        if duration_str and own_in_death_row:
+            # Own items on death row - hold the batch, no new additions
             preview_candidates = waiting_media_items
             if waiting_media_items:
                 logger.debug(
@@ -582,7 +592,7 @@ class Deleterr:
                     len(waiting_media_items),
                 )
         else:
-            # No duration or empty death row - add new candidates as usual
+            # No duration, empty own death row, or only foreign items - add new candidates
             waiting_ids = {m.get("id") for m in waiting_media_items}
             new_candidates = [
                 m for m in all_deletion_candidates
@@ -590,7 +600,7 @@ class Deleterr:
             ][:preview_next]
             preview_candidates = waiting_media_items + new_candidates
 
-        return saved_space, deleted_items, preview_candidates, saved_plex_items, all_death_row_plex_items
+        return saved_space, deleted_items, preview_candidates, saved_plex_items, all_death_row_plex_items, foreign_plex_items
 
     def _get_deletion_candidates(self, library, media_instance, plex_library, media_type, all_data=None, limit=None):
         """
@@ -657,7 +667,7 @@ class Deleterr:
 
                     if leaving_soon_config:
                         # Death row pattern: delete previously tagged items, tag new preview
-                        space, deleted, preview, saved, prior_death_row = self._process_death_row(
+                        space, deleted, preview, saved, prior_death_row, foreign = self._process_death_row(
                             library, radarr, "movie"
                         )
                     else:
@@ -667,6 +677,7 @@ class Deleterr:
                         )
                         saved = []
                         prior_death_row = None
+                        foreign = []
 
                     saved_space += space
                     self.libraries_processed += 1
@@ -684,6 +695,7 @@ class Deleterr:
                         self._process_library_leaving_soon(
                             library, preview, "movie", saved_plex_items=saved,
                             death_row_plex_items=prior_death_row,
+                            foreign_plex_items=foreign,
                         )
                     elif not leaving_soon_config:
                         # Normal flow: preview items will be deleted on next run
@@ -725,7 +737,7 @@ class Deleterr:
 
                     if leaving_soon_config:
                         # Death row pattern: delete previously tagged items, tag new preview
-                        space, deleted, preview, saved, prior_death_row = self._process_death_row(
+                        space, deleted, preview, saved, prior_death_row, foreign = self._process_death_row(
                             library, sonarr, "show", unfiltered_all_show_data
                         )
                     else:
@@ -735,6 +747,7 @@ class Deleterr:
                         )
                         saved = []
                         prior_death_row = None
+                        foreign = []
 
                     saved_space += space
                     self.libraries_processed += 1
@@ -752,6 +765,7 @@ class Deleterr:
                         self._process_library_leaving_soon(
                             library, preview, "show", saved_plex_items=saved,
                             death_row_plex_items=prior_death_row,
+                            foreign_plex_items=foreign,
                         )
                     elif not leaving_soon_config:
                         # Normal flow: preview items will be deleted on next run
@@ -769,7 +783,7 @@ class Deleterr:
             # Log preview of next scheduled deletions
             self._log_preview(all_preview, "show")
 
-    def _process_library_leaving_soon(self, library, preview, media_type, saved_plex_items=None, death_row_plex_items=None):
+    def _process_library_leaving_soon(self, library, preview, media_type, saved_plex_items=None, death_row_plex_items=None, foreign_plex_items=None):
         """
         Process leaving_soon feature for a library.
 
@@ -786,6 +800,9 @@ class Deleterr:
             death_row_plex_items: List of Plex items that were on death row before processing.
                                   Used to preserve state entries during cleanup when multiple
                                   library entries share the same Plex library name.
+            foreign_plex_items: List of Plex items in the collection/labels that belong to
+                                another library entry sharing the same Plex library name.
+                                These must be preserved through collection/label updates.
         """
         from app.media_cleaner import compute_deletion_date
 
@@ -855,7 +872,8 @@ class Deleterr:
 
         # Process leaving_soon - tag preview items for next run
         resolved_plex_items = self.media_cleaner.process_leaving_soon(
-            library, plex_library, preview, media_type, deletion_date=deletion_date
+            library, plex_library, preview, media_type, deletion_date=deletion_date,
+            preserve_plex_items=foreign_plex_items,
         )
 
         # Record tagged timestamps for duration enforcement

--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -920,7 +920,7 @@ class MediaCleaner:
 
         return items_to_delete
 
-    def process_leaving_soon(self, library_config, plex_library, items_to_tag, media_type, deletion_date=None):
+    def process_leaving_soon(self, library_config, plex_library, items_to_tag, media_type, deletion_date=None, preserve_plex_items=None):
         """
         Update leaving soon collection and labels for preview items.
 
@@ -932,6 +932,9 @@ class MediaCleaner:
             items_to_tag: List of media items from Radarr/Sonarr to tag
             media_type: 'movie' or 'show'
             deletion_date: Optional datetime when items will be deleted
+            preserve_plex_items: List of Plex items from other library entries sharing the
+                                 same Plex library name. These are kept in the collection/labels
+                                 but not treated as newly tagged items.
 
         Returns:
             List of resolved Plex items (same order as items_to_tag, None for unresolved)
@@ -971,18 +974,33 @@ class MediaCleaner:
             f"Processing leaving_soon for library '{library_name}': {len(plex_items)} items to tag"
         )
 
+        # Combine own items with preserved foreign items for collection/label updates
+        all_collection_items = list(plex_items)
+        if preserve_plex_items:
+            # Avoid duplicates by ratingKey
+            existing_keys = {item.ratingKey for item in plex_items}
+            for item in preserve_plex_items:
+                if item.ratingKey not in existing_keys:
+                    all_collection_items.append(item)
+            if len(all_collection_items) > len(plex_items):
+                logger.debug(
+                    "Preserving %d foreign items in leaving_soon collection/labels for library '%s'",
+                    len(all_collection_items) - len(plex_items),
+                    library_name,
+                )
+
         # Update collection (presence of config = enabled)
         collection_config = leaving_soon_config.get("collection")
         if collection_config is not None:
             self._update_leaving_soon_collection(
-                plex_library, plex_items, collection_config, deletion_date=deletion_date
+                plex_library, all_collection_items, collection_config, deletion_date=deletion_date
             )
 
         # Update labels (presence of config = enabled)
         labels_config = leaving_soon_config.get("labels")
         if labels_config is not None:
             self._update_leaving_soon_labels(
-                plex_library, plex_items, labels_config
+                plex_library, all_collection_items, labels_config
             )
 
         return resolved_plex_items

--- a/tests/test_leaving_soon.py
+++ b/tests/test_leaving_soon.py
@@ -540,7 +540,7 @@ class TestDeathRowIntersectionLogic:
         deleterr_instance.media_server.find_item.return_value = plex_item_a
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, radarr_instance, "movie"
             )
 
@@ -575,7 +575,7 @@ class TestDeathRowIntersectionLogic:
         deleterr_instance._get_deletion_candidates = MagicMock(return_value=[])
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, radarr_instance, "movie"
             )
 
@@ -622,7 +622,7 @@ class TestDeathRowIntersectionLogic:
         deleterr_instance.media_server.find_item.return_value = plex_item_c
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, radarr_instance, "movie"
             )
 
@@ -681,7 +681,7 @@ class TestDeathRowIntersectionLogic:
         deleterr_instance.media_server.find_item.side_effect = find_item_side_effect
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, radarr_instance, "movie"
             )
 
@@ -738,7 +738,7 @@ class TestDeathRowIntersectionLogic:
         deleterr_instance.media_server.find_item.return_value = plex_item_a
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, sonarr_instance, "show", unfiltered_all_show_data
             )
 
@@ -1002,7 +1002,7 @@ class TestLeavingSoonPreviewDoesNotDuplicate:
 
         # Mock _process_death_row to return preview items
         deleterr_instance._process_death_row = MagicMock(
-            return_value=(0, [], preview_items, [], [])  # saved_space=0, deleted=[], preview=items, saved=[], prior=[]
+            return_value=(0, [], preview_items, [], [], [])  # saved_space=0, deleted=[], preview=items, saved=[], prior=[], foreign=[]
         )
 
         # Track what _log_preview receives
@@ -1046,7 +1046,7 @@ class TestLeavingSoonPreviewDoesNotDuplicate:
 
         # Mock _process_death_row to return preview items
         deleterr_instance._process_death_row = MagicMock(
-            return_value=(0, [], preview_items, [], [])  # saved_space=0, deleted=[], preview=items, saved=[], prior=[]
+            return_value=(0, [], preview_items, [], [], [])  # saved_space=0, deleted=[], preview=items, saved=[], prior=[], foreign=[]
         )
 
         # Track what _log_preview receives
@@ -1137,7 +1137,7 @@ class TestLeavingSoonPreviewDoesNotDuplicate:
         call_count = [0]
 
         def mock_death_row(*args):
-            return (0, [], leaving_soon_preview, [], [])
+            return (0, [], leaving_soon_preview, [], [], [])
 
         def mock_normal(*args):
             return (0, [], normal_preview)
@@ -1231,7 +1231,7 @@ class TestThresholdNotMetClearsDeathRow:
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=False):
             from app.deleterr import Deleterr
             # Call the actual method
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, deleterr_instance.radarr["Radarr"], "movie"
             )
 
@@ -1600,7 +1600,7 @@ class TestDeathRowDeletionErrorHandling:
         deleterr_instance.media_server.find_item.side_effect = find_item_side_effect
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, radarr_instance, "movie"
             )
 
@@ -1631,7 +1631,7 @@ class TestDeathRowDeletionErrorHandling:
         deleterr_instance.media_server.find_item.return_value = plex_item
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, radarr_instance, "movie"
             )
 
@@ -1718,7 +1718,7 @@ class TestDeathRowDeletionErrorHandling:
         deleterr_instance.media_server.find_item.side_effect = find_item_side_effect
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted, preview, _saved, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
                 library, sonarr_instance, "show"
             )
 
@@ -1727,3 +1727,169 @@ class TestDeathRowDeletionErrorHandling:
         # Only Show B should be in deleted (Show A failed)
         assert len(deleted) == 1
         assert deleted[0]["title"] == "Show B"
+
+
+class TestSharedCollectionPreservation:
+    """Tests for preserving foreign items when multiple library entries share a Plex library.
+
+    When two library entries target the same Plex library name (e.g., "TV Shows" with
+    different series_type filters), they share the same leaving_soon collection. Each
+    entry must preserve items tagged by the other entry when updating the collection.
+    See: https://github.com/rfsbraz/deleterr/issues/259
+    """
+
+    @pytest.fixture
+    def mock_config(self):
+        return MagicMock(
+            settings={
+                "dry_run": False,
+                "plex": {"url": "http://localhost:32400", "token": "test_token"},
+                "radarr": [],
+                "sonarr": [{"name": "Sonarr", "url": "http://localhost:8989", "api_key": "test"}],
+                "libraries": [],
+                "ssl_verify": False,
+            }
+        )
+
+    @pytest.fixture
+    def deleterr_instance(self, mock_config):
+        with patch("app.deleterr.PlexMediaServer"), \
+             patch("app.deleterr.MediaCleaner"), \
+             patch("app.deleterr.NotificationManager"), \
+             patch("app.deleterr.DRadarr"), \
+             patch("app.deleterr.DSonarr"):
+
+            from app.deleterr import Deleterr
+
+            instance = object.__new__(Deleterr)
+            instance.config = mock_config
+            instance.media_server = MagicMock()
+            instance.media_cleaner = MagicMock()
+            instance.state_manager = MagicMock()
+            instance.notifications = MagicMock()
+            instance.notifications.is_leaving_soon_enabled.return_value = False
+            instance.run_result = MagicMock()
+            instance.sonarr = {"Sonarr": MagicMock()}
+            instance.radarr = {}
+            instance.libraries_processed = 0
+            instance.libraries_failed = 0
+
+            return instance
+
+    def test_foreign_items_returned_when_not_in_candidates(self, deleterr_instance):
+        """Items in death row but not in this entry's candidates are returned as foreign."""
+        library = {
+            "name": "TV Shows",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}, "duration": "7d"},
+            "max_actions_per_run": 10,
+        }
+
+        # Entry 1 (daily) has show A in death row, but only show B is a candidate
+        plex_item_a = MagicMock(ratingKey=100)  # Tagged by entry 2 (standard)
+        plex_item_b = MagicMock(ratingKey=200)  # Tagged by entry 1 (daily)
+
+        deleterr_instance._get_death_row_items = MagicMock(
+            return_value=[plex_item_a, plex_item_b]
+        )
+
+        # Only show B matches this entry's deletion rules
+        media_b = {"id": 2, "title": "Daily Show B", "tvdbId": 200, "year": 2024,
+                   "statistics": {"sizeOnDisk": 5000, "episodeFileCount": 10}}
+        deleterr_instance._get_deletion_candidates = MagicMock(return_value=[media_b])
+
+        # find_item maps media_b -> plex_item_b, media_a is not a candidate so not looked up
+        def find_item_side_effect(lib, **kwargs):
+            if kwargs.get("tvdb_id") == 200:
+                return plex_item_b
+            return None
+
+        deleterr_instance.media_server.find_item.side_effect = find_item_side_effect
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+        deleterr_instance.media_server.get_collection.return_value = MagicMock()
+
+        # State has both items tagged (by different entries, but same library name)
+        from datetime import datetime, timedelta
+        now = datetime.now()
+        deleterr_instance.state_manager.get_tagged_dates.return_value = {
+            "100": (now - timedelta(days=10)).isoformat(),
+            "200": (now - timedelta(days=10)).isoformat(),
+        }
+
+        with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
+            _, deleted, preview, saved, _, foreign = deleterr_instance._process_death_row(
+                library, deleterr_instance.sonarr["Sonarr"], "show"
+            )
+
+        # Show B was deleted (in candidates + eligible)
+        assert len(deleted) == 1
+        assert deleted[0]["title"] == "Daily Show B"
+
+        # Show A is foreign (in collection but not in this entry's candidates)
+        assert len(foreign) == 1
+        assert foreign[0].ratingKey == 100
+
+    def test_foreign_items_preserved_in_collection_update(self, standard_config, mock_media_server):
+        """Foreign items from other entries are included in collection update."""
+        mock_media_server.get_or_create_collection.return_value = MagicMock()
+
+        cleaner = MediaCleaner(standard_config, media_server=mock_media_server)
+
+        library_config = {
+            "name": "TV Shows",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}},
+        }
+        plex_library = MagicMock()
+
+        # This entry's items to tag
+        own_plex_item = MagicMock(ratingKey=200)
+        mock_media_server.find_item.return_value = own_plex_item
+
+        items_to_tag = [
+            {"title": "Daily Show", "year": 2024, "tvdbId": 200, "imdbId": None},
+        ]
+
+        # Foreign item from another entry
+        foreign_plex_item = MagicMock(ratingKey=100)
+
+        cleaner.process_leaving_soon(
+            library_config, plex_library, items_to_tag, "show",
+            preserve_plex_items=[foreign_plex_item],
+        )
+
+        # Collection should be updated with BOTH own and foreign items
+        set_items_call = mock_media_server.set_collection_items
+        assert set_items_call.called
+        collection_items = set_items_call.call_args[0][1]
+        item_keys = {item.ratingKey for item in collection_items}
+        assert 200 in item_keys, "Own item should be in collection"
+        assert 100 in item_keys, "Foreign item should be preserved in collection"
+
+    def test_foreign_items_not_duplicated(self, standard_config, mock_media_server):
+        """Foreign items already in own items are not duplicated."""
+        mock_media_server.get_or_create_collection.return_value = MagicMock()
+
+        cleaner = MediaCleaner(standard_config, media_server=mock_media_server)
+
+        library_config = {
+            "name": "TV Shows",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}},
+        }
+        plex_library = MagicMock()
+
+        plex_item = MagicMock(ratingKey=200)
+        mock_media_server.find_item.return_value = plex_item
+
+        items_to_tag = [
+            {"title": "Show", "year": 2024, "tvdbId": 200, "imdbId": None},
+        ]
+
+        # Same item passed as both own and foreign (edge case)
+        cleaner.process_leaving_soon(
+            library_config, plex_library, items_to_tag, "show",
+            preserve_plex_items=[plex_item],
+        )
+
+        # Should not duplicate
+        set_items_call = mock_media_server.set_collection_items
+        collection_items = set_items_call.call_args[0][1]
+        assert len(collection_items) == 1, "Item should not be duplicated"

--- a/tests/test_leaving_soon_duration.py
+++ b/tests/test_leaving_soon_duration.py
@@ -391,7 +391,7 @@ class TestDurationEnforcement:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior, _foreign = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -444,7 +444,7 @@ class TestDurationEnforcement:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior, _foreign = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -499,7 +499,7 @@ class TestDurationEnforcement:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior, _foreign = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -581,7 +581,7 @@ class TestBatchSize:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            _, _, preview_candidates, _, _ = deleterr_instance._process_death_row(
+            _, _, preview_candidates, _, _, _ = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -617,7 +617,7 @@ class TestBatchSize:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            _, _, preview_candidates, _, _ = deleterr_instance._process_death_row(
+            _, _, preview_candidates, _, _, _ = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -652,7 +652,7 @@ class TestBatchSize:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            _, _, preview_candidates, _, _ = deleterr_instance._process_death_row(
+            _, _, preview_candidates, _, _, _ = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -688,7 +688,7 @@ class TestBatchSize:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            _, _, preview_candidates, _, _ = deleterr_instance._process_death_row(
+            _, _, preview_candidates, _, _, _ = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -723,7 +723,7 @@ class TestBatchSize:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            _, _, preview_candidates, _, _ = deleterr_instance._process_death_row(
+            _, _, preview_candidates, _, _, _ = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 
@@ -965,7 +965,7 @@ class TestSavedItems:
         }
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
-            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior = deleterr_instance._process_death_row(
+            saved_space, deleted_items, preview_candidates, saved_plex_items, _prior, _foreign = deleterr_instance._process_death_row(
                 library, MagicMock(), "movie"
             )
 


### PR DESCRIPTION
## Summary

- When multiple library entries target the same Plex library name with different `series_type` filters (e.g., daily vs standard), they share the same leaving_soon collection
- Previously, each entry overwrote the collection with only its own items, causing the other entry's items to be dropped and re-tagged every run
- Items in the collection that aren't in the current entry's deletion candidates are now preserved through collection/label updates
- Uses state manager tagged dates to correctly identify "saved" items (watched/excluded since tagging) vs unmatched items from other entries