### PR TITLE
fix: Copy scripts into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # Copy the current directory contents into the container at /app
 COPY ./app /app/app
+COPY ./scripts /app/scripts
 COPY requirements.txt /app
 
 RUN \


### PR DESCRIPTION
## Summary

Fix Docker image so documented notification test command actually works.

The image now includes `scripts/test_notifications.py`, which documentation already tells users to run via:

`docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications`

Without this change, that command fails because the `scripts/` package was not copied into the container.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD or build changes

## Testing Done

Built Docker image locally and verified notification test script exists and runs inside container.

Commands used:

`docker build -t deleterr-test-notifications .`

`docker run --rm deleterr-test-notifications sh -lc 'ls -l /app/scripts && test -f /app/scripts/test_notifications.py'`

`docker run --rm deleterr-test-notifications python -m scripts.test_notifications --help`

## Checklist

- [ ] Tests pass (`make unit`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (if applicable)
