### PR TITLE
fix(notifications): make test notification script work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # Copy the current directory contents into the container at /app
 COPY ./app /app/app
+COPY ./scripts /app/scripts
 COPY requirements.txt /app
 
 RUN \

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -275,9 +275,13 @@ docker run --rm -v ./config:/config deleterr \
 docker run --rm -v ./config:/config deleterr \
   python -m scripts.test_notifications --type run_summary
 
-# Test specific provider only
+# Test a specific provider only for leaving_soon notifications
 docker run --rm -v ./config:/config deleterr \
   python -m scripts.test_notifications --provider email
+
+# Test a specific provider only for run summary notifications
+docker run --rm -v ./config:/config deleterr \
+  python -m scripts.test_notifications --type run_summary --provider email
 
 # Preview without sending (dry run)
 docker run --rm -v ./config:/config deleterr \

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -593,8 +593,11 @@ docker run --rm -v ./config:/config deleterr python -m scripts.test_notification
 # Test run summary notifications
 docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications --type run_summary
 
-# Test a specific provider only
+# Test a specific provider only for leaving_soon notifications
 docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications --provider email
+
+# Test a specific provider only for run summary notifications
+docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications --type run_summary --provider email
 
 # Preview without sending (dry run)
 docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications --dry-run

--- a/scripts/test_notifications.py
+++ b/scripts/test_notifications.py
@@ -15,8 +15,11 @@ Examples:
     # Test all leaving_soon notifications
     docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications
 
-    # Test only email provider
+    # Test only email provider for leaving_soon notifications
     docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications --provider email
+
+    # Test only email provider for run summary notifications
+    docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications --type run_summary --provider email
 
     # Test run summary notifications
     docker run --rm -v ./config:/config deleterr python -m scripts.test_notifications --type run_summary
@@ -26,6 +29,7 @@ Examples:
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -37,6 +41,39 @@ from app.config import load_config
 from app.modules.notifications.models import DeletedItem, RunResult
 from app.modules.notifications.manager import NotificationManager
 
+DEFAULT_CONFIG_PATH = "/config/settings.yaml"
+
+
+def init_console_logging() -> None:
+    """Initialize console logging for the standalone script."""
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logger.init_logger(console=True, verbose=log_level == "DEBUG")
+
+
+def filter_providers(
+    manager: NotificationManager,
+    provider_filter: str | None,
+    leaving_soon: bool = False,
+) -> bool:
+    """Optionally limit the manager to a single provider by name."""
+    if not provider_filter:
+        return True
+
+    attr_name = "leaving_soon_providers" if leaving_soon else "providers"
+    providers = getattr(manager, attr_name)
+    filtered_providers = [provider for provider in providers if provider.name == provider_filter]
+    setattr(manager, attr_name, filtered_providers)
+
+    if filtered_providers:
+        logger.info(f"Testing only provider: {provider_filter}")
+        return True
+
+    notification_type = "leaving_soon" if leaving_soon else "run_summary"
+    logger.warning(
+        f"Provider '{provider_filter}' is not configured for {notification_type} notifications"
+    )
+    return False
+
 
 def create_sample_items() -> list[DeletedItem]:
     """Create sample DeletedItem objects for testing."""
@@ -47,9 +84,7 @@ def create_sample_items() -> list[DeletedItem]:
             media_type="movie",
             size_bytes=15_000_000_000,  # 15 GB
             library_name="Movies",
-            plex_id=12345,
-            tmdb_id=603,
-            imdb_id="tt0133093",
+            instance_name="Radarr",
         ),
         DeletedItem(
             title="Inception",
@@ -57,9 +92,7 @@ def create_sample_items() -> list[DeletedItem]:
             media_type="movie",
             size_bytes=12_500_000_000,  # 12.5 GB
             library_name="Movies",
-            plex_id=12346,
-            tmdb_id=27205,
-            imdb_id="tt1375666",
+            instance_name="Radarr",
         ),
         DeletedItem(
             title="Interstellar",
@@ -67,9 +100,7 @@ def create_sample_items() -> list[DeletedItem]:
             media_type="movie",
             size_bytes=18_000_000_000,  # 18 GB
             library_name="4K Movies",
-            plex_id=12347,
-            tmdb_id=157336,
-            imdb_id="tt0816692",
+            instance_name="Radarr",
         ),
         DeletedItem(
             title="Breaking Bad",
@@ -77,9 +108,7 @@ def create_sample_items() -> list[DeletedItem]:
             media_type="show",
             size_bytes=85_000_000_000,  # 85 GB
             library_name="TV Shows",
-            plex_id=22345,
-            tmdb_id=1396,
-            imdb_id="tt0903747",
+            instance_name="Sonarr",
         ),
         DeletedItem(
             title="The Office",
@@ -87,9 +116,7 @@ def create_sample_items() -> list[DeletedItem]:
             media_type="show",
             size_bytes=120_000_000_000,  # 120 GB
             library_name="TV Shows",
-            plex_id=22346,
-            tmdb_id=2316,
-            imdb_id="tt0386676",
+            instance_name="Sonarr",
         ),
     ]
 
@@ -99,14 +126,14 @@ def create_sample_run_result(is_dry_run: bool = False) -> RunResult:
     items = create_sample_items()
     movies = [item for item in items if item.media_type == "movie"]
     shows = [item for item in items if item.media_type == "show"]
-
-    return RunResult(
-        deleted_movies=movies[:2],  # 2 deleted movies
-        deleted_shows=shows[:1],     # 1 deleted show
-        preview_items=items[2:],     # remaining as preview
-        total_freed_bytes=sum(item.size_bytes for item in movies[:2] + shows[:1]),
-        is_dry_run=is_dry_run,
-    )
+    result = RunResult(is_dry_run=is_dry_run)
+    for item in movies[:2]:  # 2 deleted movies
+        result.add_deleted(item)
+    for item in shows[:1]:  # 1 deleted show
+        result.add_deleted(item)
+    for item in items[2:]:  # remaining as preview
+        result.add_preview(item)
+    return result
 
 
 def test_leaving_soon(
@@ -120,23 +147,28 @@ def test_leaving_soon(
         logger.warning("No leaving_soon notifications configured")
         return False
 
+    if not filter_providers(manager, provider_filter, leaving_soon=True):
+        return False
+
     items = create_sample_items()
 
     # Get URLs from config
     plex_url = None
-    overseerr_url = None
+    seerr_url = None
 
     if "plex" in config:
         plex_url = config["plex"].get("url")
-    if "overseerr" in config:
-        overseerr_url = config["overseerr"].get("url")
+    if "seerr" in config:
+        seerr_url = config["seerr"].get("url")
+    elif "overseerr" in config:
+        seerr_url = config["overseerr"].get("url")
 
     logger.info("=" * 60)
     logger.info("Testing Leaving Soon Notifications")
     logger.info("=" * 60)
     logger.info(f"Sample items: {len(items)} ({sum(1 for i in items if i.media_type == 'movie')} movies, {sum(1 for i in items if i.media_type == 'show')} shows)")
     logger.info(f"Plex URL: {plex_url or 'Not configured'}")
-    logger.info(f"Overseerr URL: {overseerr_url or 'Not configured'}")
+    logger.info(f"Seerr URL: {seerr_url or 'Not configured'}")
     logger.info("-" * 60)
 
     if dry_run:
@@ -148,7 +180,7 @@ def test_leaving_soon(
     success = manager.send_leaving_soon(
         items=items,
         plex_url=plex_url,
-        overseerr_url=overseerr_url,
+        seerr_url=seerr_url,
     )
 
     if success:
@@ -165,11 +197,14 @@ def test_run_summary(
     dry_run: bool = False,
 ) -> bool:
     """Test run summary notifications."""
-    if not manager.enabled:
+    if not manager.is_enabled():
         logger.warning("Notifications are disabled in config")
         return False
 
-    result = create_sample_run_result(is_dry_run=False)
+    if not filter_providers(manager, provider_filter, leaving_soon=False):
+        return False
+
+    result = create_sample_run_result(is_dry_run=dry_run)
 
     logger.info("=" * 60)
     logger.info("Testing Run Summary Notifications")
@@ -184,7 +219,7 @@ def test_run_summary(
         logger.info("[DRY-RUN] Would send run summary notification")
         return True
 
-    success = manager.send(result)
+    success = manager.send_run_summary(result)
 
     if success:
         logger.info("Run summary notification sent successfully!")
@@ -230,6 +265,8 @@ def show_config_status(config: dict) -> None:
 
 
 def main():
+    init_console_logging()
+
     parser = argparse.ArgumentParser(
         description="Test notification providers with sample data",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -256,35 +293,42 @@ def main():
         action="store_true",
         help="Show configuration status only",
     )
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Path to config file (default: {DEFAULT_CONFIG_PATH})",
+    )
 
     args = parser.parse_args()
 
     # Load config
     try:
-        config = load_config()
+        config = load_config(args.config)
     except Exception as e:
         logger.error(f"Failed to load config: {e}")
-        logger.error("Make sure /config/settings.yaml exists and is valid")
+        logger.error(f"Make sure {args.config} exists and is valid")
         sys.exit(1)
 
+    settings = config.settings
+
     if args.status:
-        show_config_status(config)
+        show_config_status(settings)
         sys.exit(0)
 
     # Show config status first
-    show_config_status(config)
+    show_config_status(settings)
 
     # Initialize notification manager
-    notifications_config = config.get("notifications", {})
+    notifications_config = settings.get("notifications", {})
     if not notifications_config:
         logger.error("No notifications configured in settings.yaml")
         sys.exit(1)
 
-    manager = NotificationManager(notifications_config)
+    manager = NotificationManager(config)
 
     # Run the appropriate test
     if args.type == "leaving_soon":
-        success = test_leaving_soon(manager, config, args.provider, args.dry_run)
+        success = test_leaving_soon(manager, settings, args.provider, args.dry_run)
     else:
         success = test_run_summary(manager, args.provider, args.dry_run)
 

--- a/tests/test_notifications_script.py
+++ b/tests/test_notifications_script.py
@@ -94,13 +94,13 @@ def test_test_leaving_soon_passes_seerr_url():
             return True
 
     config = {
-        "plex": {"url": "http://plex.example.com"},
-        "seerr": {"url": "http://seerr.example.com"},
+        "plex": {"url": "https://plex.example.com"},
+        "seerr": {"url": "https://seerr.example.com"},
     }
 
     assert test_notifications.test_leaving_soon(FakeManager(), config) is True
-    assert captured["plex_url"] == "http://plex.example.com"
-    assert captured["seerr_url"] == "http://seerr.example.com"
+    assert captured["plex_url"] == "https://plex.example.com"
+    assert captured["seerr_url"] == "https://seerr.example.com"
 
 
 def test_filter_providers_limits_run_summary_manager():

--- a/tests/test_notifications_script.py
+++ b/tests/test_notifications_script.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import test_notifications
+
+
+def test_status_uses_default_config_path_and_settings(monkeypatch):
+    fake_config = SimpleNamespace(settings={"notifications": {"email": {"enabled": True}}})
+    seen: dict[str, object] = {}
+
+    def fake_load_config(path):
+        seen["path"] = path
+        return fake_config
+
+    def fake_show_config_status(config):
+        seen["status_config"] = config
+
+    monkeypatch.setattr(test_notifications, "load_config", fake_load_config)
+    monkeypatch.setattr(test_notifications, "show_config_status", fake_show_config_status)
+    monkeypatch.setattr(
+        test_notifications.sys,
+        "argv",
+        ["test_notifications.py", "--status"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        test_notifications.main()
+
+    assert exc.value.code == 0
+    assert seen["path"] == "/config/settings.yaml"
+    assert seen["status_config"] == fake_config.settings
+
+
+def test_run_summary_uses_config_object_for_notification_manager(monkeypatch):
+    fake_config = SimpleNamespace(settings={"notifications": {"enabled": True}})
+    seen: dict[str, object] = {}
+
+    def fake_load_config(path):
+        seen["path"] = path
+        return fake_config
+
+    def fake_show_config_status(config):
+        seen["status_config"] = config
+
+    class FakeNotificationManager:
+        def __init__(self, config):
+            seen["manager_config"] = config
+
+    def fake_test_run_summary(manager, provider_filter=None, dry_run=False):
+        seen["run_summary_args"] = (manager, provider_filter, dry_run)
+        return True
+
+    monkeypatch.setattr(test_notifications, "load_config", fake_load_config)
+    monkeypatch.setattr(test_notifications, "show_config_status", fake_show_config_status)
+    monkeypatch.setattr(test_notifications, "NotificationManager", FakeNotificationManager)
+    monkeypatch.setattr(test_notifications, "test_run_summary", fake_test_run_summary)
+    monkeypatch.setattr(
+        test_notifications.sys,
+        "argv",
+        ["test_notifications.py", "--type", "run_summary", "--dry-run"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        test_notifications.main()
+
+    assert exc.value.code == 0
+    assert seen["path"] == "/config/settings.yaml"
+    assert seen["status_config"] == fake_config.settings
+    assert seen["manager_config"] is fake_config
+    assert seen["run_summary_args"][1:] == (None, True)
+
+
+def test_test_run_summary_uses_current_manager_api():
+    class FakeManager:
+        def is_enabled(self):
+            return True
+
+        def send_run_summary(self, result):
+            return True
+
+    assert test_notifications.test_run_summary(FakeManager(), dry_run=False) is True
+
+
+def test_test_leaving_soon_passes_seerr_url():
+    captured: dict[str, object] = {}
+
+    class FakeManager:
+        def is_leaving_soon_enabled(self):
+            return True
+
+        def send_leaving_soon(self, **kwargs):
+            captured.update(kwargs)
+            return True
+
+    config = {
+        "plex": {"url": "http://plex.example.com"},
+        "seerr": {"url": "http://seerr.example.com"},
+    }
+
+    assert test_notifications.test_leaving_soon(FakeManager(), config) is True
+    assert captured["plex_url"] == "http://plex.example.com"
+    assert captured["seerr_url"] == "http://seerr.example.com"
+
+
+def test_filter_providers_limits_run_summary_manager():
+    email_provider = SimpleNamespace(name="email")
+    discord_provider = SimpleNamespace(name="discord")
+    manager = SimpleNamespace(providers=[email_provider, discord_provider])
+
+    assert test_notifications.filter_providers(manager, "email") is True
+    assert manager.providers == [email_provider]
+
+
+def test_filter_providers_rejects_missing_provider():
+    manager = SimpleNamespace(providers=[SimpleNamespace(name="discord")])
+
+    assert test_notifications.filter_providers(manager, "email") is False
+    assert manager.providers == []


### PR DESCRIPTION
## Summary

Fix `scripts/test_notifications.py` so it actually works as documented in the container image.

Changes included:
- copy `scripts/` into Docker image so `python -m scripts.test_notifications` exists in container
- fix script drift against current app code (`load_config`, `NotificationManager`, notification models, `seerr` handling)
- initialize console logging so `--status` prints output
- make provider filtering work as expected
- clarify docs/examples for `--provider` with `run_summary` vs default `leaving_soon`
- add tests covering the script behavior

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] CI/CD or build changes

## Testing Done

Verified behavior in Docker container with mounted `/config/settings.yaml`:
- `python -m scripts.test_notifications --status`
- `python -m scripts.test_notifications --type run_summary --dry-run`
- `python -m scripts.test_notifications --provider email --dry-run`
- `python -m scripts.test_notifications --type run_summary --provider telegram`

## Checklist

- [x] Tests pass (`make unit`)
- [x] New tests added for new functionality (if applicable)
- [x] Documentation updated (if applicable)