### PR TITLE
fix(leaving-soon): drop saved items from collection instead of preserving them as foreign

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -542,29 +542,47 @@ class Deleterr:
 
         deleted_ids = {m.get("id") for m in deleted_items}
 
-        # Get media items for duration-waiting Plex items (they need to stay in collection).
-        # Items waiting but NOT in this entry's candidates are "foreign" - tagged by another
-        # library entry sharing the same Plex library/collection. These are preserved as raw
-        # Plex items since we can't look up their Radarr/Sonarr data.
+        # Distinguish items this entry owns from items tagged by another library entry
+        # sharing the same Plex library/collection name.
+        #
+        # An item is OWN if it belongs to this entry's media universe (everything the entry
+        # manages, BEFORE deletion rules are applied). Own items that are not current deletion
+        # candidates have been "saved" since tagging (watched, excluded, or no longer past
+        # threshold) and must LEAVE the collection - they are no longer leaving soon.
+        #
+        # An item is FOREIGN if it is NOT in this entry's universe; it was tagged by a sibling
+        # library entry and must be PRESERVED so that entry doesn't lose its items.
+        #
+        # Using candidate membership alone (the previous heuristic) wrongly treated own saved
+        # items as foreign and preserved them forever, causing the collection to grow without
+        # bound across runs.
+        universe_ids = self._get_universe_ids(library, media_instance, media_type, all_data)
+        own_plex_keys = set(candidate_by_plex_key.keys())
+        for item in all_death_row_plex_items:
+            if self._is_universe_member(item, universe_ids):
+                own_plex_keys.add(item.ratingKey)
+
+        # Get media items for duration-waiting Plex items that are still deletion candidates
+        # (they need to stay in the collection until their duration elapses).
         waiting_media_items = []
         foreign_plex_items = []
         if duration_waiting_items:
-            waiting_keys = {item.ratingKey for item in duration_waiting_items}
             waiting_media_items = [
-                candidate_by_plex_key[key]
-                for key in waiting_keys
-                if key in candidate_by_plex_key
+                candidate_by_plex_key[item.ratingKey]
+                for item in duration_waiting_items
+                if item.ratingKey in candidate_by_plex_key
             ]
-            # Foreign waiting items: in collection but not this entry's candidates
+            # Foreign waiting items belong to another library entry, not this one.
             foreign_plex_items = [
                 item for item in duration_waiting_items
-                if item.ratingKey not in candidate_by_plex_key
+                if item.ratingKey not in own_plex_keys
             ]
 
-        # Also preserve eligible items from other entries (their duration may differ)
+        # Preserve eligible (duration elapsed) items from other entries too. Own eligible
+        # items that aren't current candidates are saved and intentionally dropped here.
         foreign_eligible = [
             item for item in death_row_plex_items
-            if item.ratingKey not in candidate_by_plex_key
+            if item.ratingKey not in own_plex_keys
         ]
         foreign_plex_items.extend(foreign_eligible)
 
@@ -643,6 +661,58 @@ class Deleterr:
                 break
 
         return candidates
+
+    def _get_universe_ids(self, library, media_instance, media_type, all_data=None):
+        """
+        Build the set of media identifiers belonging to a library entry's universe.
+
+        The "universe" is every item the entry manages BEFORE deletion rules are applied
+        (all movies in the Radarr instance, or the shows matching this entry's filters).
+        It is used to tell items this entry tagged (own) apart from items tagged by another
+        library entry sharing the same Plex library/collection name (foreign).
+
+        Returns:
+            dict with 'tmdb', 'tvdb', 'imdb' id sets. Empty sets on failure - a conservative
+            fallback that treats unknown items as foreign and preserves them, rather than
+            risking removal of a sibling entry's items.
+        """
+        ids = {"tmdb": set(), "tvdb": set(), "imdb": set()}
+        try:
+            if media_type == "movie":
+                media_data = media_instance.get_movies()
+            else:
+                media_data = (
+                    self.media_cleaner.filter_shows(library, all_data) if all_data else []
+                )
+            for item in media_data:
+                if item.get("tmdbId"):
+                    ids["tmdb"].add(item["tmdbId"])
+                if item.get("tvdbId"):
+                    ids["tvdb"].add(item["tvdbId"])
+                if item.get("imdbId"):
+                    ids["imdb"].add(item["imdbId"])
+        except Exception as e:
+            logger.debug(
+                "Could not build media universe for library '%s': %s. "
+                "Death row items will be conservatively treated as foreign.",
+                library.get("name", "Unknown"),
+                e,
+            )
+
+        return ids
+
+    def _is_universe_member(self, plex_item, universe_ids):
+        """
+        Check whether a Plex item maps to a media item in the entry's universe.
+
+        Returns True only when one of the item's GUIDs matches a known universe id.
+        """
+        guids = self.media_server.get_guids(plex_item)
+        return bool(
+            (guids.get("tmdb_id") and guids["tmdb_id"] in universe_ids["tmdb"])
+            or (guids.get("tvdb_id") and guids["tvdb_id"] in universe_ids["tvdb"])
+            or (guids.get("imdb_id") and guids["imdb_id"] in universe_ids["imdb"])
+        )
 
     def process_radarr(self):
         for name, radarr in self.radarr.items():

--- a/tests/test_leaving_soon_duration.py
+++ b/tests/test_leaving_soon_duration.py
@@ -975,6 +975,123 @@ class TestSavedItems:
         assert len(saved_plex_items) == 1
         assert saved_plex_items[0].title == "Saved Movie"
 
+    def test_saved_items_not_preserved_as_foreign(self, deleterr_instance):
+        """
+        Regression: own items that no longer match deletion criteria must LEAVE the
+        collection, not be preserved as 'foreign'.
+
+        A single-entry library has no sibling entries, so nothing is ever foreign. Before
+        the fix, every protected death-row item was misclassified as foreign and re-added
+        to the collection on every run, growing it without bound.
+        """
+        now = datetime.now()
+        # All three items eligible (tagged long enough ago)
+        deleterr_instance.state_manager.set_tagged_dates("Movies", {
+            "100": (now - timedelta(days=10)).isoformat(),
+            "200": (now - timedelta(days=10)).isoformat(),
+            "300": (now - timedelta(days=10)).isoformat(),
+        })
+
+        plex_100 = self._make_plex_item(100, "Deleted Movie")
+        plex_200 = self._make_plex_item(200, "Saved Movie A")
+        plex_300 = self._make_plex_item(300, "Saved Movie B")
+
+        deleterr_instance._get_death_row_items = MagicMock(
+            return_value=[plex_100, plex_200, plex_300]
+        )
+
+        # Only movie 100 still matches deletion criteria; 200 and 300 were watched/protected.
+        media_100 = {"id": 1, "title": "Deleted Movie", "tmdbId": 100, "year": 2024, "sizeOnDisk": 1000}
+        deleterr_instance._get_deletion_candidates = MagicMock(return_value=[media_100])
+
+        # The universe (all Radarr movies) contains all three - they are all OWN items.
+        media_instance = MagicMock()
+        media_instance.get_movies.return_value = [
+            media_100,
+            {"id": 2, "title": "Saved Movie A", "tmdbId": 200, "year": 2024},
+            {"id": 3, "title": "Saved Movie B", "tmdbId": 300, "year": 2024},
+        ]
+
+        guid_map = {100: 100, 200: 200, 300: 300}
+
+        def get_guids_side_effect(item):
+            return {"tmdb_id": guid_map.get(item.ratingKey), "tvdb_id": None, "imdb_id": None}
+
+        deleterr_instance.media_server.get_guids.side_effect = get_guids_side_effect
+
+        def find_item_side_effect(lib, **kwargs):
+            return plex_100 if kwargs.get("tmdb_id") == 100 else None
+
+        deleterr_instance.media_server.find_item.side_effect = find_item_side_effect
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+
+        library = {
+            "name": "Movies",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}, "duration": "7d"},
+            "max_actions_per_run": 10,
+        }
+
+        with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
+            _, deleted_items, _, saved_plex_items, _prior, foreign = deleterr_instance._process_death_row(
+                library, media_instance, "movie"
+            )
+
+        # Movie 100 deleted; 200 and 300 saved.
+        assert len(deleted_items) == 1
+        assert {item.ratingKey for item in saved_plex_items} == {200, 300}
+        # Crucially, the saved items are NOT preserved as foreign - they leave the collection.
+        assert foreign == []
+
+    def test_foreign_items_preserved_via_universe(self, deleterr_instance):
+        """
+        With sibling entries (same Plex library name), an item tagged by another entry
+        is not in this entry's universe and must be preserved in the shared collection.
+        """
+        now = datetime.now()
+        deleterr_instance.state_manager.set_tagged_dates("TV Shows", {
+            "100": (now - timedelta(days=10)).isoformat(),  # foreign (other entry)
+            "200": (now - timedelta(days=10)).isoformat(),  # own, saved
+        })
+
+        plex_foreign = self._make_plex_item(100, "Standard Show")
+        plex_own = self._make_plex_item(200, "Daily Show")
+
+        deleterr_instance._get_death_row_items = MagicMock(
+            return_value=[plex_foreign, plex_own]
+        )
+
+        # No current deletion candidates for this entry (the own show was saved).
+        deleterr_instance._get_deletion_candidates = MagicMock(return_value=[])
+
+        # This entry's universe (filter_shows) contains only the own show (tvdb 200).
+        deleterr_instance.media_cleaner.filter_shows.return_value = [
+            {"id": 2, "title": "Daily Show", "tvdbId": 200},
+        ]
+
+        guid_map = {100: 999, 200: 200}  # 999 is not in the universe -> foreign
+
+        def get_guids_side_effect(item):
+            return {"tmdb_id": None, "tvdb_id": guid_map.get(item.ratingKey), "imdb_id": None}
+
+        deleterr_instance.media_server.get_guids.side_effect = get_guids_side_effect
+        deleterr_instance.media_server.find_item.return_value = None
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+
+        library = {
+            "name": "TV Shows",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}, "duration": "7d"},
+            "series_type": "daily",
+            "max_actions_per_run": 10,
+        }
+
+        with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
+            _, _, _, _saved, _prior, foreign = deleterr_instance._process_death_row(
+                library, MagicMock(), "show", all_data=[{"id": 2, "title": "Daily Show", "tvdbId": 200}]
+            )
+
+        # The foreign show (other entry) is preserved; the own saved show is not.
+        assert {item.ratingKey for item in foreign} == {100}
+
 
 class TestFormatTitleWithLibrary:
     """Tests for DeletedItem.format_title_with_library()."""


### PR DESCRIPTION
- The death row pattern misclassified own items that no longer match deletion rules (watched, excluded, under threshold) as "foreign" and re-preserved them in the Leaving Soon collection every run, so the collection grew without bound (observed 142 items in a single-entry Movies library).
- Foreign-vs-own is now decided by the entry's media universe (all items it manages, before deletion rules) instead of current deletion-candidate membership. Own items not currently matching are dropped (saved); items outside the universe are preserved for sibling library entries (keeps #264 behavior).
- New helpers `_get_universe_ids` / `_is_universe_member` build the universe id-set from Radarr/Sonarr and match death-row items by GUID, with a conservative preserve-on-failure fallback.
- Added regression tests covering both the single-entry saved case and the sibling-entry foreign-preservation case.