### PR TITLE
fix(leaving-soon): only count own items as saved, not a sibling entry's

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -452,17 +452,34 @@ class Deleterr:
         saved_plex_items = []
         is_dry_run = self.config.settings.get("dry_run", True)
 
+        # Distinguish items this entry OWNS (in its media universe) from FOREIGN items tagged by
+        # a sibling library entry sharing the same Plex library/collection name. Death-row state
+        # is keyed by library name, so two entries with the same name (e.g. "TV Shows" split by
+        # series_type) share state; without this distinction a sibling's items get misclassified.
+        # Computed once here and reused for the collection rebuild below.
+        universe_ids = self._get_universe_ids(library, media_instance, media_type, all_data)
+        own_plex_keys = set(candidate_by_plex_key.keys())
+        for item in all_death_row_plex_items:
+            if self._is_universe_member(item, universe_ids):
+                own_plex_keys.add(item.ratingKey)
+
         # Log death row status and identify saved items.
-        # An item is "saved" if it's on death row, has a state entry (was tagged by this
-        # library name), but is NOT being deleted. This correctly identifies items that were
-        # previously eligible but are now protected (watched, excluded, etc.), even when
-        # multiple library entries share the same Plex library/collection name.
+        # An item is "saved" only if it is OWN (in this entry's universe), has a state entry (was
+        # tagged under this library name), and is NOT being deleted - i.e. it was eligible when
+        # tagged but is now protected (watched, excluded, no longer past threshold). FOREIGN items
+        # belonging to a sibling entry must NOT be reported as saved: the sibling may still be
+        # deleting them in this same run, which previously produced contradictory
+        # "Saved from Deletion" + "Deleted" notifications for the same titles.
         if death_row_plex_items:
             tagged_dates = self.state_manager.get_tagged_dates(library_name)
             delete_keys = {k for k in candidate_by_plex_key if candidate_by_plex_key[k] in items_to_delete}
             for plex_item in death_row_plex_items:
                 key = str(plex_item.ratingKey)
-                if key in tagged_dates and plex_item.ratingKey not in delete_keys:
+                if (
+                    key in tagged_dates
+                    and plex_item.ratingKey not in delete_keys
+                    and plex_item.ratingKey in own_plex_keys
+                ):
                     saved_plex_items.append(plex_item)
 
             unmatched_count = len(death_row_plex_items) - len(items_to_delete)
@@ -556,11 +573,7 @@ class Deleterr:
         # Using candidate membership alone (the previous heuristic) wrongly treated own saved
         # items as foreign and preserved them forever, causing the collection to grow without
         # bound across runs.
-        universe_ids = self._get_universe_ids(library, media_instance, media_type, all_data)
-        own_plex_keys = set(candidate_by_plex_key.keys())
-        for item in all_death_row_plex_items:
-            if self._is_universe_member(item, universe_ids):
-                own_plex_keys.add(item.ratingKey)
+        # (universe_ids and own_plex_keys are computed above, right after items_to_delete.)
 
         # Get media items for duration-waiting Plex items that are still deletion candidates
         # (they need to stay in the collection until their duration elapses).

--- a/tests/test_leaving_soon_duration.py
+++ b/tests/test_leaving_soon_duration.py
@@ -947,7 +947,13 @@ class TestSavedItems:
 
         # Only item 100 still matches deletion criteria (200 was watched)
         media_100 = {"id": 1, "title": "Deleted Movie", "tmdbId": "tt001", "year": 2024, "sizeOnDisk": 1000}
+        media_200 = {"id": 2, "title": "Saved Movie", "tmdbId": "tt002", "year": 2024, "sizeOnDisk": 2000}
         deleterr_instance._get_deletion_candidates = MagicMock(return_value=[media_100])
+
+        # The entry's universe (all movies in Radarr, before deletion rules) includes both, so
+        # item 200 is recognised as OWN -> a genuine save, not a foreign sibling's item.
+        media_instance = MagicMock()
+        media_instance.get_movies.return_value = [media_100, media_200]
 
         def find_item_side_effect(lib, **kwargs):
             tmdb = kwargs.get("tmdb_id")
@@ -956,6 +962,11 @@ class TestSavedItems:
             return None
 
         deleterr_instance.media_server.find_item.side_effect = find_item_side_effect
+        deleterr_instance.media_server.get_guids.side_effect = lambda item: (
+            {"tmdb_id": "tt001"} if item is plex_item_100
+            else {"tmdb_id": "tt002"} if item is plex_item_200
+            else {}
+        )
         deleterr_instance.media_server.get_library.return_value = MagicMock()
 
         library = {
@@ -966,7 +977,7 @@ class TestSavedItems:
 
         with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
             saved_space, deleted_items, preview_candidates, saved_plex_items, _prior, _foreign = deleterr_instance._process_death_row(
-                library, MagicMock(), "movie"
+                library, media_instance, "movie"
             )
 
         # Item 100 was deleted, item 200 was saved
@@ -974,6 +985,44 @@ class TestSavedItems:
         assert deleted_items[0]["title"] == "Deleted Movie"
         assert len(saved_plex_items) == 1
         assert saved_plex_items[0].title == "Saved Movie"
+
+    def test_foreign_death_row_item_not_reported_as_saved(self, deleterr_instance):
+        """A death-row item tagged by a sibling entry (same library name, not in this entry's
+        universe) must NOT be reported as 'saved' - the sibling may delete it in the same run,
+        which previously produced contradictory Saved + Deleted notifications for one title."""
+        now = datetime.now()
+        # Shared state under the common library name includes the sibling's item.
+        deleterr_instance.state_manager.set_tagged_dates("Movies", {
+            "300": (now - timedelta(days=10)).isoformat(),
+        })
+
+        foreign_item = self._make_plex_item(300, "Foreign Sibling Movie")
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[foreign_item])
+
+        # This entry has no deletion candidates and an empty universe -> item 300 is foreign.
+        deleterr_instance._get_deletion_candidates = MagicMock(return_value=[])
+        media_instance = MagicMock()
+        media_instance.get_movies.return_value = []
+
+        deleterr_instance.media_server.find_item.return_value = None
+        deleterr_instance.media_server.get_guids.side_effect = lambda item: {"tmdb_id": "tt300"}
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+
+        library = {
+            "name": "Movies",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}, "duration": "7d"},
+            "max_actions_per_run": 10,
+        }
+
+        with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
+            _space, deleted_items, _preview, saved_plex_items, _prior, foreign_plex_items = deleterr_instance._process_death_row(
+                library, media_instance, "movie"
+            )
+
+        # Foreign item: not deleted by this entry, not "saved", and preserved as foreign.
+        assert deleted_items == []
+        assert saved_plex_items == []
+        assert any(i.ratingKey == 300 for i in foreign_plex_items)
 
     def test_saved_items_not_preserved_as_foreign(self, deleterr_instance):
         """


### PR DESCRIPTION
## Summary
- Fixes leaving-soon reporting the **same titles as both "Saved from Deletion" and "Deleted"** in a single run.
- **Root cause:** when two library entries share one Plex library/collection (e.g. a `TV Shows` library split into `standard` and `daily` entries), death-row state is keyed by the shared library name. The saved-items detection only checked "tagged under this name AND not deleted by me," so it flagged a *sibling's* items as "saved" even while that sibling deleted them in the same run.
- **Fix:** an item is "saved" only if it belongs to this entry's media universe (own). Foreign items tagged by a sibling entry are no longer reported as saved. This reuses the same own/foreign universe model already used for the collection rebuild, applied earlier in `_process_death_row`.
- Updates the existing saved-items test to model the entry universe, and adds a regression test asserting a foreign death-row item is not reported as saved.

All 821 tests pass.