### PR TITLE
fix(exclusions): match Sonarr shows against Trakt lists by tvdbId

### DIFF
--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -1479,11 +1479,16 @@ class MediaCleaner:
         return True
 
     def check_trakt_movies(self, media_data, trakt_movies):
-        if media_data.get("tvdb_id", media_data.get("tmdbId")) in trakt_movies:
-            logger.debug(
-                f"{media_data['title']} found in trakt watched list {trakt_movies[media_data.get('tvdb_id', media_data.get('tmdbId'))]['list']}, skipping"
-            )
-            return False
+        if not trakt_movies:
+            return True
+
+        # Check by tmdbId (movies) or tvdbId (shows)
+        for media_id in (media_data.get("tmdbId"), media_data.get("tvdbId")):
+            if media_id and media_id in trakt_movies:
+                logger.debug(
+                    f"{media_data['title']} found in trakt watched list {trakt_movies[media_id]['list']}, skipping"
+                )
+                return False
 
         return True
 

--- a/tests/test_media_cleaner.py
+++ b/tests/test_media_cleaner.py
@@ -1649,9 +1649,16 @@ def test_check_collections(
 @pytest.mark.parametrize(
     "media_data, trakt_movies, expected",
     [
-        ({"title": "movie1", "tvdb_id": "1"}, {"1": {"list": "watched"}}, False),
-        ({"title": "movie2", "tmdbId": "2"}, {"2": {"list": "watched"}}, False),
-        ({"title": "movie3", "tvdb_id": "3"}, {"4": {"list": "watched"}}, True),
+        # Movie found in trakt list by tmdbId → excluded
+        ({"title": "movie1", "tmdbId": 123}, {123: {"list": "https://trakt.tv/users/user/lists/list"}}, False),
+        # Show found in trakt list by tvdbId → excluded
+        ({"title": "show1", "tvdbId": 456}, {456: {"list": "https://trakt.tv/users/user/lists/list"}}, False),
+        # Show with both ids matches the trakt list keyed by tvdbId → excluded
+        ({"title": "show2", "tmdbId": 789, "tvdbId": 456}, {456: {"list": "url"}}, False),
+        # Item not found in trakt list → actionable
+        ({"title": "movie2", "tmdbId": 789}, {123: {"list": "url"}}, True),
+        # Empty trakt dict → actionable
+        ({"title": "movie3", "tmdbId": 999}, {}, True),
     ],
 )
 def test_check_trakt_movies(media_data, trakt_movies, expected, media_cleaner):


### PR DESCRIPTION
- check_trakt_movies looked up media_data["tvdb_id"], but Sonarr series dicts use the camelCase key "tvdbId", so the lookup always fell through to "tmdbId" and Trakt list exclusions never matched TV shows, letting excluded shows proceed toward deletion
- Match against both tmdbId (movies) and tvdbId (shows), mirroring the existing check_mdblist_items pattern, and fix the debug log that repeated the wrong key
- Update the check_trakt_movies unit tests with realistic Sonarr/Radarr-shaped data and int-keyed Trakt dicts, covering movie, show, both-ids, no-match, and empty-list cases