### PR TITLE
fix(media_cleaner): treat missing dry_run setting as dry run

### DIFF
--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -612,7 +612,7 @@ class MediaCleaner:
         disk_size = sonarr_show.get("statistics", {}).get("sizeOnDisk", 0)
         total_episodes = sonarr_show.get("statistics", {}).get("episodeFileCount", 0)
 
-        is_dry_run = self.config.settings.get("dry_run")
+        is_dry_run = self.config.settings.get("dry_run", True)
 
         logger.log_deletion(
             title=sonarr_show["title"],
@@ -759,7 +759,7 @@ class MediaCleaner:
     ):
         disk_size = radarr_movie.get("sizeOnDisk", 0)
 
-        is_dry_run = self.config.settings.get("dry_run")
+        is_dry_run = self.config.settings.get("dry_run", True)
 
         logger.log_deletion(
             title=radarr_movie["title"],

--- a/tests/test_media_cleaner.py
+++ b/tests/test_media_cleaner.py
@@ -436,6 +436,37 @@ def test_process_show_not_dry_run(mock_delete_show_if_allowed, standard_config):
     assert result == 100
 
 
+@patch.object(MediaCleaner, "delete_show_if_allowed")
+def test_process_show_missing_dry_run_defaults_to_dry_run(
+    mock_delete_show_if_allowed, standard_config
+):
+    # Arrange
+    library = {}
+    sonarr_instance = MagicMock()
+    sonarr_show = {
+        "title": "Test Show",
+        "statistics": {"sizeOnDisk": 100, "episodeFileCount": 10},
+    }
+    actions_performed = 0
+    max_actions_per_run = 1
+
+    media_cleaner = MediaCleaner(standard_config)
+    media_cleaner.config.settings = {}
+
+    # Act
+    result = media_cleaner.process_show(
+        library,
+        sonarr_instance,
+        sonarr_show,
+        actions_performed,
+        max_actions_per_run,
+    )
+
+    # Assert
+    mock_delete_show_if_allowed.assert_not_called()
+    assert result == 100
+
+
 def test_check_exclusions(mocker, standard_config):
     # Arrange
     library = {"name": "Test Library", "exclude": {}}
@@ -936,6 +967,34 @@ def test_process_movie_dry_run(mock_delete_movie_if_allowed, standard_config):
 
     media_cleaner_instance = MediaCleaner(standard_config)
     media_cleaner_instance.config.settings = {"dry_run": True}
+
+    # Act
+    result = media_cleaner_instance.process_movie(
+        library,
+        radarr_instance,
+        radarr_movie,
+        actions_performed,
+        max_actions_per_run,
+    )
+
+    # Assert
+    mock_delete_movie_if_allowed.assert_not_called()
+    assert result == radarr_movie["sizeOnDisk"]
+
+
+@patch("app.media_cleaner.MediaCleaner.delete_movie_if_allowed")
+def test_process_movie_missing_dry_run_defaults_to_dry_run(
+    mock_delete_movie_if_allowed, standard_config
+):
+    # Arrange
+    library = {"name": "Test Library"}
+    radarr_instance = MagicMock()
+    radarr_movie = {"title": "Test Movie", "sizeOnDisk": 100}
+    actions_performed = 0
+    max_actions_per_run = 1
+
+    media_cleaner_instance = MediaCleaner(standard_config)
+    media_cleaner_instance.config.settings = {}
 
     # Act
     result = media_cleaner_instance.process_movie(


### PR DESCRIPTION
- process_movie and process_show read dry_run from the raw config dict without a default, so omitting dry_run from the YAML returned None and the run proceeded with live deletions instead of the schema's safe default of true
- Both reads now use .get("dry_run", True), matching the deletion-gating reads in deleterr.py
- Added unit tests covering configs that omit dry_run, asserting no delete call is made