### PR TITLE
fix(notifications): add timeout to SMTP connections

### DIFF
--- a/app/modules/notifications/providers/email.py
+++ b/app/modules/notifications/providers/email.py
@@ -15,6 +15,9 @@ from app.modules.notifications.models import DeletedItem, RunResult
 # Default template path
 DEFAULT_TEMPLATE_PATH = Path(__file__).parent.parent.parent.parent / "templates" / "leaving_soon.html"
 
+# Timeout for SMTP connections so an unresponsive server doesn't hang the run
+SMTP_TIMEOUT_SECONDS = 30
+
 
 class EmailProvider(BaseNotificationProvider):
     """Email notification provider with SMTP support and HTML templates."""
@@ -121,10 +124,12 @@ class EmailProvider(BaseNotificationProvider):
 
         if use_ssl:
             # Implicit SSL (typically port 465)
-            smtp = smtplib.SMTP_SSL(smtp_server, smtp_port, context=context)
+            smtp = smtplib.SMTP_SSL(
+                smtp_server, smtp_port, context=context, timeout=SMTP_TIMEOUT_SECONDS
+            )
         else:
             # Plain or STARTTLS (typically port 587 or 25)
-            smtp = smtplib.SMTP(smtp_server, smtp_port)
+            smtp = smtplib.SMTP(smtp_server, smtp_port, timeout=SMTP_TIMEOUT_SECONDS)
             if use_tls:
                 smtp.starttls(context=context)
 

--- a/tests/modules/notifications/test_providers.py
+++ b/tests/modules/notifications/test_providers.py
@@ -524,6 +524,50 @@ class TestEmailProvider:
         mock_smtp_ssl_class.assert_called_once()
 
     @patch("app.modules.notifications.providers.email.smtplib.SMTP")
+    def test_smtp_connection_uses_timeout(self, mock_smtp_class):
+        """Test plain/STARTTLS SMTP connection is created with a timeout."""
+        from app.modules.notifications.providers.email import SMTP_TIMEOUT_SECONDS
+
+        mock_smtp = MagicMock()
+        mock_smtp_class.return_value = mock_smtp
+
+        provider = EmailProvider({
+            "smtp_server": "smtp.example.com",
+            "smtp_port": 587,
+            "from_address": "test@example.com",
+            "to_addresses": ["user@example.com"],
+        })
+
+        provider._create_smtp_connection()
+
+        mock_smtp_class.assert_called_once_with(
+            "smtp.example.com", 587, timeout=SMTP_TIMEOUT_SECONDS
+        )
+
+    @patch("app.modules.notifications.providers.email.smtplib.SMTP_SSL")
+    def test_smtp_ssl_connection_uses_timeout(self, mock_smtp_ssl_class):
+        """Test implicit SSL SMTP connection is created with a timeout."""
+        from app.modules.notifications.providers.email import SMTP_TIMEOUT_SECONDS
+
+        mock_smtp = MagicMock()
+        mock_smtp_ssl_class.return_value = mock_smtp
+
+        provider = EmailProvider({
+            "smtp_server": "smtp.example.com",
+            "smtp_port": 465,
+            "from_address": "test@example.com",
+            "to_addresses": ["user@example.com"],
+            "use_ssl": True,
+            "use_tls": False,
+        })
+
+        provider._create_smtp_connection()
+
+        assert mock_smtp_ssl_class.call_count == 1
+        _, kwargs = mock_smtp_ssl_class.call_args
+        assert kwargs["timeout"] == SMTP_TIMEOUT_SECONDS
+
+    @patch("app.modules.notifications.providers.email.smtplib.SMTP")
     def test_send_failure(self, mock_smtp_class):
         """Test failed email send."""
         mock_smtp_class.side_effect = Exception("Connection failed")


### PR DESCRIPTION
- SMTP connections were created without a timeout, so an unresponsive SMTP server could hang the entire Deleterr run indefinitely
- Pass a 30 second timeout (module-level constant) to both the SMTP and SMTP_SSL constructors in the email provider
- Add unit tests asserting both constructors receive the timeout