### PR TITLE
fix(leaving-soon): retry series whose deletion was skipped instead of clearing state

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -522,7 +522,11 @@ class Deleterr:
                         )
                         self.media_cleaner._update_seerr_status(library, media_item, "movie")
                     else:
-                        self.media_cleaner.delete_series(media_instance, media_item)
+                        if not self.media_cleaner.delete_series(media_instance, media_item):
+                            # Deletion was skipped (e.g. an episode file is in use).
+                            # Keep the item in the leaving_soon state so it is
+                            # retried on the next run.
+                            continue
                         self.media_cleaner._update_seerr_status(library, media_item, "tv")
                 except Exception as e:
                     logger.error(

--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -639,7 +639,8 @@ class MediaCleaner:
             sonarr_instance,
             sonarr_show,
     ):
-        self.delete_series(sonarr_instance, sonarr_show)
+        if not self.delete_series(sonarr_instance, sonarr_show):
+            return
 
         # Update Seerr status after successful deletion
         self._update_seerr_status(library, sonarr_show, "tv")
@@ -779,7 +780,15 @@ class MediaCleaner:
 
         return disk_size
 
-    def delete_series(self, sonarr, sonarr_show):
+    def delete_series(self, sonarr, sonarr_show) -> bool:
+        """
+        Delete a series and its episode files from Sonarr.
+
+        Returns:
+            bool: True if the series was deleted, False if deletion was skipped
+                because an episode file could not be deleted (callers must keep
+                the item pending so it is retried on the next run).
+        """
         # PyArr doesn't support deleting the series files, so we need to do it manually
         episodes = sonarr.get_episode(sonarr_show["id"], series=True)
 
@@ -815,12 +824,14 @@ class MediaCleaner:
                 break
 
         # delete the series
-        if not skip_deleting_show:
-            sonarr.del_series(sonarr_show["id"], delete_files=True)
-        else:
+        if skip_deleting_show:
             logger.warning(
                 f"Skipping deletion of '{sonarr_show['title']}' - will be deleted on the next run"
             )
+            return False
+
+        sonarr.del_series(sonarr_show["id"], delete_files=True)
+        return True
 
     def delete_movie_if_allowed(
             self,

--- a/tests/test_leaving_soon.py
+++ b/tests/test_leaving_soon.py
@@ -1696,7 +1696,7 @@ class TestDeathRowDeletionErrorHandling:
         sonarr_instance = deleterr_instance.sonarr["Sonarr"]
         # First call raises, second succeeds
         deleterr_instance.media_cleaner.delete_series.side_effect = [
-            Exception("Sonarr API timeout"), None
+            Exception("Sonarr API timeout"), True
         ]
 
         deleterr_instance.media_server.get_library.return_value = MagicMock()
@@ -1727,6 +1727,46 @@ class TestDeathRowDeletionErrorHandling:
         # Only Show B should be in deleted (Show A failed)
         assert len(deleted) == 1
         assert deleted[0]["title"] == "Show B"
+
+    def test_show_skipped_deletion_keeps_state_for_retry(self, deleterr_instance):
+        """A show whose deletion was skipped (delete_series returns False) is not
+        counted as deleted and its leaving_soon state is kept so it is retried."""
+        library = {
+            "name": "TV Shows",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}},
+            "preview_next": 5,
+        }
+
+        plex_item = MagicMock(ratingKey=2001)
+        sonarr_show = {
+            "id": 201, "title": "Stuck Show", "tvdbId": 81189,
+            "statistics": {"sizeOnDisk": 5000, "episodeFileCount": 10},
+        }
+
+        sonarr_instance = deleterr_instance.sonarr["Sonarr"]
+        # delete_series signals a skipped deletion (e.g. episode file in use)
+        deleterr_instance.media_cleaner.delete_series.return_value = False
+
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+        deleterr_instance.media_server.get_collection.return_value = MagicMock()
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[plex_item])
+        deleterr_instance._get_deletion_candidates = MagicMock(return_value=[sonarr_show])
+        deleterr_instance.media_server.find_item.return_value = plex_item
+
+        with patch("app.media_cleaner.library_meets_disk_space_threshold", return_value=True):
+            saved_space, deleted, preview, _saved, _prior, _foreign = deleterr_instance._process_death_row(
+                library, sonarr_instance, "show"
+            )
+
+        deleterr_instance.media_cleaner.delete_series.assert_called_once_with(
+            sonarr_instance, sonarr_show
+        )
+        # The show was not deleted, so it must not be counted as deleted
+        assert len(deleted) == 0
+        # Seerr must not be told the show was deleted
+        deleterr_instance.media_cleaner._update_seerr_status.assert_not_called()
+        # State must be kept so the show is retried on the next run
+        deleterr_instance.state_manager.remove_items.assert_not_called()
 
 
 class TestSharedCollectionPreservation:

--- a/tests/test_media_cleaner.py
+++ b/tests/test_media_cleaner.py
@@ -969,7 +969,7 @@ def test_delete_series_server_error(standard_config):
     media_cleaner_instance = MediaCleaner(standard_config)
 
     # Act
-    media_cleaner_instance.delete_series(mock_sonarr, sonarr_show)
+    result = media_cleaner_instance.delete_series(mock_sonarr, sonarr_show)
 
     # Assert
     mock_sonarr.get_episode.assert_called_once_with(sonarr_show["id"], series=True)
@@ -978,6 +978,7 @@ def test_delete_series_server_error(standard_config):
     )
     assert mock_sonarr.del_episode_file.call_count == 2
     mock_sonarr.del_series.assert_not_called()
+    assert result is False
 
 
 def test_delete_series_resource_not_found(standard_config):
@@ -998,7 +999,7 @@ def test_delete_series_resource_not_found(standard_config):
     media_cleaner_instance = MediaCleaner(standard_config)
 
     # Act
-    media_cleaner_instance.delete_series(mock_sonarr, sonarr_show)
+    result = media_cleaner_instance.delete_series(mock_sonarr, sonarr_show)
 
     # Assert
     mock_sonarr.get_episode.assert_called_once_with(sonarr_show["id"], series=True)
@@ -1007,6 +1008,7 @@ def test_delete_series_resource_not_found(standard_config):
     )
     assert mock_sonarr.del_episode_file.call_count == 2
     mock_sonarr.del_series.assert_called_once_with(sonarr_show["id"], delete_files=True)
+    assert result is True
 
 
 def test_delete_series_no_errors(standard_config):
@@ -1023,7 +1025,7 @@ def test_delete_series_no_errors(standard_config):
     media_cleaner_instance = MediaCleaner(standard_config)
 
     # Act
-    media_cleaner_instance.delete_series(mock_sonarr, sonarr_show)
+    result = media_cleaner_instance.delete_series(mock_sonarr, sonarr_show)
 
     # Assert
     mock_sonarr.get_episode.assert_called_once_with(sonarr_show["id"], series=True)
@@ -1032,6 +1034,28 @@ def test_delete_series_no_errors(standard_config):
     )
     assert mock_sonarr.del_episode_file.call_count == 2
     mock_sonarr.del_series.assert_called_once_with(sonarr_show["id"], delete_files=True)
+    assert result is True
+
+
+def test_delete_show_if_allowed_skips_seerr_update_when_deletion_skipped(standard_config):
+    # Arrange
+    library = {"name": "Test Library"}
+    mock_sonarr = MagicMock()
+    sonarr_show = {"id": 1, "title": "Test Show"}
+
+    media_cleaner_instance = MediaCleaner(standard_config)
+
+    with patch.object(
+        MediaCleaner, "delete_series", return_value=False
+    ) as mock_delete_series, patch.object(
+        MediaCleaner, "_update_seerr_status"
+    ) as mock_update_seerr:
+        # Act
+        media_cleaner_instance.delete_show_if_allowed(library, mock_sonarr, sonarr_show)
+
+    # Assert
+    mock_delete_series.assert_called_once_with(mock_sonarr, sonarr_show)
+    mock_update_seerr.assert_not_called()
 
 
 def test_delete_movie_if_allowed(standard_config):


### PR DESCRIPTION
- When an episode file could not be deleted (in use, locked, or a Sonarr server error), `delete_series` skipped removing the series but returned normally, so the death-row flow counted the show as deleted, cleared its leaving-soon state, and never retried it despite logging that it would be deleted on the next run.
- `delete_series` now returns a bool indicating whether the series was actually deleted. `_process_death_row` keeps the item's state on a skipped deletion so it stays on death row and is retried next run, and the regular flow skips the Seerr status update for shows that were not deleted.
- Added unit tests covering the skipped-deletion path: the series is not removed from Sonarr, the item is not counted as deleted, and its state entry is preserved.