### PR TITLE
fix(leaving-soon): look up Sonarr series by TVDB ID correctly

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -300,9 +300,13 @@ class Deleterr:
         # Try TVDB ID first (most reliable for shows)
         if guids.get("tvdb_id"):
             try:
-                series = sonarr_instance.get_series(guids["tvdb_id"])
-                if series:
+                series = sonarr_instance.get_series_by_tvdb(guids["tvdb_id"])
+                # Sonarr returns a list when looking up by TVDB ID, but be
+                # defensive in case a single dict is returned
+                if isinstance(series, dict):
                     return series
+                if series:
+                    return series[0]
             except Exception as e:
                 logger.debug(f"Sonarr lookup by TVDB ID {guids.get('tvdb_id')} failed: {e}")
 

--- a/app/modules/sonarr.py
+++ b/app/modules/sonarr.py
@@ -32,7 +32,7 @@ class DSonarr:
         return self.instance.get_series()
 
     def get_series_by_tvdb(self, tvdb_id):
-        return self.instance.get_series(tvdb_id=tvdb_id)
+        return self.instance.get_series(tvdb_id, tvdb=True)
 
     def get_tags(self):
         if not self.tags:

--- a/tests/test_deleterr.py
+++ b/tests/test_deleterr.py
@@ -66,6 +66,69 @@ def test_process_sonarr(radarr_mock, sonarr_mock, deleterr):
     )
 
 
+class TestLookupSonarrShow:
+    """Tests for Deleterr._lookup_sonarr_show."""
+
+    def test_tvdb_lookup_returns_first_series_from_list(self, deleterr):
+        """TVDB lookup returns a list; the first series dict is returned."""
+        deleterr.media_server.get_guids = MagicMock(
+            return_value={"tvdb_id": 12345, "imdb_id": "tt0000001"}
+        )
+        series = {"id": 1, "title": "Test Show", "tvdbId": 12345}
+        sonarr_instance = MagicMock(
+            get_series_by_tvdb=MagicMock(return_value=[series])
+        )
+
+        result = deleterr._lookup_sonarr_show(MagicMock(title="Test Show"), sonarr_instance)
+
+        assert result == series
+        sonarr_instance.get_series_by_tvdb.assert_called_once_with(12345)
+        sonarr_instance.get_series.assert_not_called()
+
+    def test_tvdb_lookup_handles_single_dict_response(self, deleterr):
+        """A single dict response from the TVDB lookup is returned as-is."""
+        deleterr.media_server.get_guids = MagicMock(return_value={"tvdb_id": 12345})
+        series = {"id": 1, "title": "Test Show", "tvdbId": 12345}
+        sonarr_instance = MagicMock(
+            get_series_by_tvdb=MagicMock(return_value=series)
+        )
+
+        result = deleterr._lookup_sonarr_show(MagicMock(title="Test Show"), sonarr_instance)
+
+        assert result == series
+
+    def test_tvdb_lookup_empty_falls_back_to_imdb(self, deleterr):
+        """An empty TVDB result falls through to the IMDB scan."""
+        deleterr.media_server.get_guids = MagicMock(
+            return_value={"tvdb_id": 12345, "imdb_id": "tt0000001"}
+        )
+        series = {"id": 2, "title": "Test Show", "imdbId": "tt0000001"}
+        sonarr_instance = MagicMock(
+            get_series_by_tvdb=MagicMock(return_value=[]),
+            get_series=MagicMock(return_value=[{"id": 9, "imdbId": "tt9999999"}, series]),
+        )
+
+        result = deleterr._lookup_sonarr_show(MagicMock(title="Test Show"), sonarr_instance)
+
+        assert result == series
+        sonarr_instance.get_series_by_tvdb.assert_called_once_with(12345)
+        sonarr_instance.get_series.assert_called_once_with()
+
+    def test_returns_none_when_not_found(self, deleterr):
+        """None is returned when neither TVDB nor IMDB lookups match."""
+        deleterr.media_server.get_guids = MagicMock(
+            return_value={"tvdb_id": 12345, "imdb_id": "tt0000001"}
+        )
+        sonarr_instance = MagicMock(
+            get_series_by_tvdb=MagicMock(return_value=[]),
+            get_series=MagicMock(return_value=[]),
+        )
+
+        result = deleterr._lookup_sonarr_show(MagicMock(title="Test Show"), sonarr_instance)
+
+        assert result is None
+
+
 class TestInstanceLock:
     """Tests for single-instance lock functionality."""
 


### PR DESCRIPTION
- The leaving soon TVDB lookup called `DSonarr.get_series()` with an argument, but that method takes none, so it always raised a TypeError that was swallowed and logged at debug level. Every show fell back to fetching all series and scanning by IMDB id, and shows without an IMDB GUID were never found.
- `DSonarr.get_series_by_tvdb()` was also broken: it passed a `tvdb_id` keyword that pyarr 5.2.0 does not accept. It now calls `get_series(tvdb_id, tvdb=True)` as pyarr expects.
- The lookup now uses `get_series_by_tvdb()` and returns the first series from the list response (handling a single dict defensively), with unit tests covering the TVDB hit, empty list fallback to IMDB, and not-found paths.