### PR TITLE
fix(tautulli): raise a clear error on invalid history responses

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -16,6 +16,7 @@ from app import logger
 from app.config import hang_on_error, load_config
 from app.media_cleaner import ConfigurationError, MediaCleaner, parse_leaving_soon_duration
 from app.modules.notifications import NotificationManager, RunResult, DeletedItem, LibraryStats
+from app.modules.tautulli import TautulliApiError
 from app.state import StateManager
 from app.utils import print_readable_freed_space
 
@@ -787,7 +788,7 @@ class Deleterr:
                     # Log library completion time
                     library_duration = time.time() - library_start
                     logger.info(f"Library '{library_name}' completed in {logger.format_duration(library_duration)}")
-                except ConfigurationError as e:
+                except (ConfigurationError, TautulliApiError) as e:
                     logger.error(str(e))
                     self.libraries_failed += 1
 
@@ -857,7 +858,7 @@ class Deleterr:
                     # Log library completion time
                     library_duration = time.time() - library_start
                     logger.info(f"Library '{library_name}' completed in {logger.format_duration(library_duration)}")
-                except ConfigurationError as e:
+                except (ConfigurationError, TautulliApiError) as e:
                     logger.error(str(e))
                     self.libraries_failed += 1
 

--- a/app/modules/tautulli.py
+++ b/app/modules/tautulli.py
@@ -9,6 +9,10 @@ from app import logger
 HISTORY_PAGE_SIZE = 300
 
 
+class TautulliApiError(Exception):
+    """Raised when Tautulli returns an invalid or unexpected API response."""
+
+
 def filter_by_most_recent(data, key, sort_key):
     # Create an empty dictionary to hold the highest stopped value for each id
     max_sort_key = {}
@@ -92,6 +96,13 @@ class Tautulli:
                 length=HISTORY_PAGE_SIZE,
                 include_activity=1,
             )
+            if not isinstance(history, dict) or "data" not in history:
+                raise TautulliApiError(
+                    f"Tautulli returned an invalid history response for section "
+                    f"{section} (offset {start}): expected a dict with a 'data' "
+                    f"key, got {type(history).__name__}. Check that Tautulli is "
+                    f"reachable and healthy before retrying."
+                )
             if not history["data"]:
                 break
 

--- a/tests/modules/test_tautulli.py
+++ b/tests/modules/test_tautulli.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.modules.tautulli import HISTORY_PAGE_SIZE, Tautulli, filter_by_most_recent
+from app.modules.tautulli import (
+    HISTORY_PAGE_SIZE,
+    Tautulli,
+    TautulliApiError,
+    filter_by_most_recent,
+)
 
 
 @pytest.mark.parametrize(
@@ -75,6 +80,56 @@ def test_fetch_history_data(mock_api):
         length=HISTORY_PAGE_SIZE,
         include_activity=1,
     )
+
+
+@patch(
+    "app.modules.tautulli.RawAPI",
+    return_value=MagicMock(get_history=MagicMock(return_value=None)),
+)
+def test_fetch_history_data_none_response_raises(mock_api):
+    """A None response (e.g. network/server error) raises a clear error."""
+    tautulli_instance = Tautulli("id", "secret")
+
+    with pytest.raises(TautulliApiError, match=r"section test_section \(offset 0\)"):
+        tautulli_instance._fetch_history_data("test_section")
+
+
+@patch(
+    "app.modules.tautulli.RawAPI",
+    return_value=MagicMock(
+        get_history=MagicMock(side_effect=[{"data": ["item1", "item2"]}, None])
+    ),
+)
+def test_fetch_history_data_none_response_mid_pagination_raises(mock_api):
+    """A failure on a later page raises instead of returning partial history."""
+    tautulli_instance = Tautulli("id", "secret")
+
+    with pytest.raises(TautulliApiError, match=r"section test_section \(offset 2\)"):
+        tautulli_instance._fetch_history_data("test_section")
+
+
+@patch(
+    "app.modules.tautulli.RawAPI",
+    return_value=MagicMock(get_history=MagicMock(return_value="<html>error</html>")),
+)
+def test_fetch_history_data_non_dict_response_raises(mock_api):
+    """A non-dict response raises a clear error mentioning the received type."""
+    tautulli_instance = Tautulli("id", "secret")
+
+    with pytest.raises(TautulliApiError, match="got str"):
+        tautulli_instance._fetch_history_data("test_section")
+
+
+@patch(
+    "app.modules.tautulli.RawAPI",
+    return_value=MagicMock(get_history=MagicMock(return_value={"error": "boom"})),
+)
+def test_fetch_history_data_missing_data_key_raises(mock_api):
+    """A dict response without a 'data' key raises a clear error."""
+    tautulli_instance = Tautulli("id", "secret")
+
+    with pytest.raises(TautulliApiError, match="expected a dict with a 'data' key"):
+        tautulli_instance._fetch_history_data("test_section")
 
 
 @patch("app.modules.tautulli.RawAPI", MagicMock())


### PR DESCRIPTION
- Tautulli's get_history can return None or a non-dict payload on network or server errors, which made _fetch_history_data crash with a raw TypeError and an unhelpful stack trace
- Guard the response in _fetch_history_data and raise a descriptive TautulliApiError that includes the section id and pagination offset, instead of continuing with partial watch history that could make watched items look unwatched
- Catch TautulliApiError in the library processing loops so the affected library is skipped with a clear error message while the rest of the run continues