### PR TITLE
fix(notifications): surface send failures in logs

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -1072,15 +1072,23 @@ class Deleterr:
         seerr_url = self.config.settings.get("seerr", {}).get("url")
 
         try:
-            self.notifications.send_leaving_soon(
+            success = self.notifications.send_leaving_soon(
                 items,
                 plex_url=plex_url,
                 seerr_url=seerr_url,
                 deletion_date=deletion_date,
                 saved_items=saved_items,
             )
+            if not success and (items or saved_items):
+                logger.error(
+                    f"Leaving soon notification failed for library '{library_name}': "
+                    "users were NOT notified about upcoming deletions"
+                )
         except Exception as e:
-            logger.error(f"Failed to send leaving_soon notification: {e}")
+            logger.error(
+                f"Failed to send leaving_soon notification for library '{library_name}': {e} "
+                "- users were NOT notified about upcoming deletions"
+            )
 
     def _log_preview(self, preview_items, media_type):
         """

--- a/app/modules/notifications/providers/discord.py
+++ b/app/modules/notifications/providers/discord.py
@@ -46,8 +46,14 @@ class DiscordProvider(BaseNotificationProvider):
             response.raise_for_status()
             return True
 
+        except requests.exceptions.HTTPError as e:
+            # Avoid logging str(e): it includes the webhook URL, which contains a secret
+            status = e.response.status_code if e.response is not None else "unknown"
+            body = e.response.text[:500] if e.response is not None else ""
+            logger.error(f"Discord notification failed: HTTP {status}, response: {body}")
+            return False
         except requests.exceptions.RequestException as e:
-            logger.error(f"Discord notification failed: {e}")
+            logger.error(f"Discord notification failed: {type(e).__name__}: {e}")
             return False
 
     def test_connection(self) -> bool:

--- a/app/modules/notifications/providers/slack.py
+++ b/app/modules/notifications/providers/slack.py
@@ -41,10 +41,22 @@ class SlackProvider(BaseNotificationProvider):
             response.raise_for_status()
 
             # Slack returns "ok" for successful requests
-            return response.text == "ok"
+            if response.text != "ok":
+                logger.error(
+                    f"Slack notification failed: webhook returned HTTP {response.status_code} "
+                    f"with unexpected body: {response.text[:500]}"
+                )
+                return False
+            return True
 
+        except requests.exceptions.HTTPError as e:
+            # Avoid logging str(e): it includes the webhook URL, which contains a secret
+            status = e.response.status_code if e.response is not None else "unknown"
+            body = e.response.text[:500] if e.response is not None else ""
+            logger.error(f"Slack notification failed: HTTP {status}, response: {body}")
+            return False
         except requests.exceptions.RequestException as e:
-            logger.error(f"Slack notification failed: {e}")
+            logger.error(f"Slack notification failed: {type(e).__name__}: {e}")
             return False
 
     def test_connection(self) -> bool:

--- a/tests/modules/notifications/test_providers.py
+++ b/tests/modules/notifications/test_providers.py
@@ -219,6 +219,62 @@ class TestDiscordProvider:
         assert success is False
 
     @patch("app.modules.notifications.providers.discord.requests.post")
+    def test_send_http_error_logs_status_and_body(self, mock_post, caplog):
+        """Test that HTTP errors log status code and response body, but not the webhook URL."""
+        import logging
+        import requests as req
+
+        webhook_url = "https://discord.com/api/webhooks/123456/secret-token"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.text = '{"message": "You are being rate limited.", "retry_after": 1.5}'
+        mock_response.raise_for_status.side_effect = req.exceptions.HTTPError(
+            f"429 Too Many Requests for url: {webhook_url}",
+            response=mock_response,
+        )
+        mock_post.return_value = mock_response
+
+        provider = DiscordProvider({"webhook_url": webhook_url})
+        result = create_test_result(deleted_movies=1)
+
+        with caplog.at_level(logging.ERROR):
+            success = provider.send(result)
+
+        assert success is False
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(
+            "429" in msg and "rate limited" in msg for msg in error_messages
+        ), f"Expected status and body in error log, got: {error_messages}"
+        # The webhook URL contains a secret and must not be logged
+        assert not any("secret-token" in msg for msg in error_messages)
+
+    @patch("app.modules.notifications.providers.discord.requests.post")
+    def test_send_http_error_truncates_body(self, mock_post, caplog):
+        """Test that long response bodies are truncated in error logs."""
+        import logging
+        import requests as req
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "x" * 2000
+        mock_response.raise_for_status.side_effect = req.exceptions.HTTPError(
+            "400 Bad Request", response=mock_response
+        )
+        mock_post.return_value = mock_response
+
+        provider = DiscordProvider({"webhook_url": "https://discord.com/api/webhooks/..."})
+        result = create_test_result(deleted_movies=1)
+
+        with caplog.at_level(logging.ERROR):
+            success = provider.send(result)
+
+        assert success is False
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_messages, "Expected an error log"
+        assert all(len(msg) < 1000 for msg in error_messages)
+
+    @patch("app.modules.notifications.providers.discord.requests.post")
     def test_custom_username(self, mock_post):
         """Test custom username."""
         mock_response = MagicMock()
@@ -284,19 +340,58 @@ class TestSlackProvider:
         mock_post.assert_called_once()
 
     @patch("app.modules.notifications.providers.slack.requests.post")
-    def test_send_not_ok(self, mock_post):
-        """Test Slack send with non-ok response."""
+    def test_send_not_ok(self, mock_post, caplog):
+        """Test Slack send with non-ok response logs an error."""
+        import logging
+
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
+        mock_response.status_code = 200
         mock_response.text = "invalid_token"
         mock_post.return_value = mock_response
 
         provider = SlackProvider({"webhook_url": "https://hooks.slack.com/services/..."})
         result = create_test_result(deleted_movies=1)
 
-        success = provider.send(result)
+        with caplog.at_level(logging.ERROR):
+            success = provider.send(result)
 
         assert success is False
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(
+            "invalid_token" in msg for msg in error_messages
+        ), f"Expected error log with response body, got: {error_messages}"
+
+    @patch("app.modules.notifications.providers.slack.requests.post")
+    def test_send_http_error_logs_status_without_url(self, mock_post, caplog):
+        """Test that HTTP errors log status and body, but not the webhook URL."""
+        import logging
+        import requests as req
+
+        webhook_url = "https://hooks.slack.com/services/T00/B00/secret-token"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "no_service"
+        mock_response.raise_for_status.side_effect = req.exceptions.HTTPError(
+            f"404 Not Found for url: {webhook_url}",
+            response=mock_response,
+        )
+        mock_post.return_value = mock_response
+
+        provider = SlackProvider({"webhook_url": webhook_url})
+        result = create_test_result(deleted_movies=1)
+
+        with caplog.at_level(logging.ERROR):
+            success = provider.send(result)
+
+        assert success is False
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(
+            "404" in msg and "no_service" in msg for msg in error_messages
+        ), f"Expected status and body in error log, got: {error_messages}"
+        # The webhook URL contains a secret and must not be logged
+        assert not any("secret-token" in msg for msg in error_messages)
 
     @patch("app.modules.notifications.providers.slack.requests.post")
     def test_custom_channel(self, mock_post):

--- a/tests/test_leaving_soon.py
+++ b/tests/test_leaving_soon.py
@@ -927,6 +927,86 @@ class TestLeavingSoonNotifications:
         assert items[0].title == "Show 1"
         assert items[0].media_type == "show"
 
+    def test_send_leaving_soon_notification_failure_logs_error(
+        self, deleterr_with_notifications, mock_notification_manager, caplog
+    ):
+        """Test that a failed leaving_soon send logs that users were not notified."""
+        import logging
+
+        mock_notification_manager.send_leaving_soon.return_value = False
+
+        library = {
+            "name": "Movies",
+            "radarr": "Radarr",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}},
+        }
+        preview = [
+            {"title": "Movie 1", "year": 2020, "tmdbId": 550, "sizeOnDisk": 1000000000},
+        ]
+
+        deleterr_with_notifications.media_server.get_library.return_value = MagicMock()
+
+        with caplog.at_level(logging.WARNING):
+            deleterr_with_notifications._process_library_leaving_soon(library, preview, "movie")
+
+        assert any(
+            record.levelno >= logging.WARNING and "NOT notified" in record.message
+            for record in caplog.records
+        ), f"Expected failure log about users not notified, got: {[r.message for r in caplog.records]}"
+
+    def test_send_leaving_soon_notification_success_no_failure_log(
+        self, deleterr_with_notifications, mock_notification_manager, caplog
+    ):
+        """Test that a successful leaving_soon send does not log a failure."""
+        import logging
+
+        mock_notification_manager.send_leaving_soon.return_value = True
+
+        library = {
+            "name": "Movies",
+            "radarr": "Radarr",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}},
+        }
+        preview = [
+            {"title": "Movie 1", "year": 2020, "tmdbId": 550, "sizeOnDisk": 1000000000},
+        ]
+
+        deleterr_with_notifications.media_server.get_library.return_value = MagicMock()
+
+        with caplog.at_level(logging.WARNING):
+            deleterr_with_notifications._process_library_leaving_soon(library, preview, "movie")
+
+        assert not any(
+            "NOT notified" in record.message for record in caplog.records
+        ), f"Unexpected failure log, got: {[r.message for r in caplog.records]}"
+
+    def test_send_leaving_soon_notification_exception_logs_error(
+        self, deleterr_with_notifications, mock_notification_manager, caplog
+    ):
+        """Test that an exception during leaving_soon send logs that users were not notified."""
+        import logging
+
+        mock_notification_manager.send_leaving_soon.side_effect = Exception("boom")
+
+        library = {
+            "name": "Movies",
+            "radarr": "Radarr",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}},
+        }
+        preview = [
+            {"title": "Movie 1", "year": 2020, "tmdbId": 550, "sizeOnDisk": 1000000000},
+        ]
+
+        deleterr_with_notifications.media_server.get_library.return_value = MagicMock()
+
+        with caplog.at_level(logging.ERROR):
+            deleterr_with_notifications._process_library_leaving_soon(library, preview, "movie")
+
+        assert any(
+            record.levelno >= logging.ERROR and "NOT notified" in record.message
+            for record in caplog.records
+        ), f"Expected exception log about users not notified, got: {[r.message for r in caplog.records]}"
+
 
 class TestLeavingSoonPreviewDoesNotDuplicate:
     """Tests ensuring leaving_soon preview items don't appear in 'would be deleted' list.


### PR DESCRIPTION
- Log an error in the leaving soon flow when the notification manager reports a failed send, so users know they were not notified about upcoming deletions
- Slack provider now logs an error when the webhook returns HTTP 200 with a non-ok body instead of failing silently
- Discord and Slack providers now log the HTTP status code and a truncated response body on HTTP errors (including 429 rate limits) instead of the exception string, which leaked the webhook URL secret