### PR TITLE
fix(trakt): support favorites lists via direct REST call

### DIFF
--- a/app/modules/trakt.py
+++ b/app/modules/trakt.py
@@ -1,12 +1,37 @@
 import re
 
+import requests
 import trakt
 
 from app import logger
 
+TRAKT_API_URL = "https://api.trakt.tv"
+
+
+class _FavoriteItem:
+    """Adapter giving Trakt REST favorites items the get_key() interface
+    that _process_trakt_item_list expects from trakt.py objects.
+
+    The favorites endpoint is not supported by the pinned trakt.py library,
+    so those items come from a direct REST call and arrive as plain dicts:
+    {"type": "movie", "movie": {"ids": {"tmdb": ..., "tvdb": ...}, ...}}
+    """
+
+    def __init__(self, data):
+        self._data = data
+
+    def get_key(self, key):
+        media = self._data.get(self._data.get("type"), {})
+        return media.get("ids", {}).get(key)
+
+    def __repr__(self):
+        media = self._data.get(self._data.get("type"), {})
+        return f"<FavoriteItem {media.get('title', 'unknown')}>"
+
 
 class Trakt:
     def __init__(self, trakt_id, trakt_secret):
+        self._trakt_id = trakt_id
         self._configure_trakt(trakt_id, trakt_secret)
 
     def _configure_trakt(self, trakt_id, trakt_secret):
@@ -69,10 +94,11 @@ class Trakt:
                 or []
             )  # Return empty list if no items are found
         elif listname == "favorites":
-            logger.warning(
-                f"Traktpy does not support {listname} {media_type}s. Skipping..."
+            # trakt.py has no favorites interface (the endpoint postdates the
+            # library), so fetch them with a direct REST call instead
+            return self._fetch_favorites_items(
+                media_type, username, max_items_per_list
             )
-            return []
 
         return (
             trakt.Trakt["users/*/lists/*"].items(
@@ -84,6 +110,27 @@ class Trakt:
             )
             or []  # Return empty list if no items are found
         )
+
+    def _fetch_favorites_items(self, media_type, username, max_items_per_list):
+        """Fetch a user's favorites via the Trakt REST API.
+
+        GET /users/{id}/favorites/{type} - a distinct top-level endpoint that
+        cannot be routed through the library's users/*/lists/* interface.
+        Public profiles only need the client id (no OAuth). Errors propagate
+        to _fetch_list_items' handler like every other list type.
+        """
+        response = requests.get(
+            f"{TRAKT_API_URL}/users/{username}/favorites/{media_type}s",
+            headers={
+                "Content-Type": "application/json",
+                "trakt-api-version": "2",
+                "trakt-api-key": self._trakt_id,
+            },
+            params={"limit": max_items_per_list},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return [_FavoriteItem(item) for item in response.json()]
 
     def _fetch_recurrent_list_items(self, media_type, listname):
         logger.warning(

--- a/docs/integrations/trakt.md
+++ b/docs/integrations/trakt.md
@@ -61,6 +61,17 @@ exclude:
       - "https://trakt.tv/users/yourusername/watchlist"
 ```
 
+### User Favorites
+
+A user's favorites (the profile must be public):
+
+```yaml
+exclude:
+  trakt:
+    lists:
+      - "https://trakt.tv/users/yourusername/favorites"
+```
+
 ### Custom User Lists
 
 Any public user list:
@@ -87,7 +98,7 @@ exclude:
 
 ## Known Limitations
 
-- **Favorites lists** (`https://trakt.tv/users/.../favorites`) are not supported by the underlying Trakt library. Use custom lists as an alternative.
+- **Favorites lists** require the user's profile to be public (deleterr authenticates with the client id only, no OAuth).
 - **Periodic lists** (e.g., `watched/weekly`, `collected/monthly`) are not currently supported.
 
 ## Full Example

--- a/tests/modules/test_trakt.py
+++ b/tests/modules/test_trakt.py
@@ -183,3 +183,88 @@ def test__fetch_general_list_items(media_type, trakt_instance_and_mock):
     # Test with other list
     result = trakt_instance._fetch_general_list_items(media_type, "other", 100)
     assert result == []
+
+
+class TestFavorites:
+    """Favorites are fetched via the Trakt REST API (issue #27)."""
+
+    def _rest_item(self, media_type, ids):
+        return {media_type: {"ids": ids, "title": "Test"}, "type": media_type}
+
+    @patch("app.modules.trakt.requests.get")
+    def test_favorites_fetched_via_rest(self, mock_get, trakt_instance_and_mock):
+        trakt_instance, _ = trakt_instance_and_mock
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            self._rest_item("movie", {"tmdb": 603, "tvdb": None}),
+            self._rest_item("movie", {"tmdb": 604, "tvdb": None}),
+        ]
+        mock_get.return_value = mock_response
+
+        result = trakt_instance._fetch_user_list_items(
+            "movie", "johndoe", "favorites", 100
+        )
+
+        # REST endpoint hit with client-id auth headers
+        args, kwargs = mock_get.call_args
+        assert args[0] == "https://api.trakt.tv/users/johndoe/favorites/movies"
+        assert kwargs["headers"]["trakt-api-key"] == "trakt_id"
+        assert kwargs["headers"]["trakt-api-version"] == "2"
+        assert kwargs["params"] == {"limit": 100}
+
+        # Items expose get_key() like trakt.py objects
+        assert [item.get_key("tmdb") for item in result] == [603, 604]
+
+    @patch("app.modules.trakt.requests.get")
+    def test_favorites_items_flow_into_exclusion_dict(
+        self, mock_get, trakt_instance_and_mock
+    ):
+        """End-to-end: a favorites URL must populate the exclusion items."""
+        trakt_instance, _ = trakt_instance_and_mock
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            self._rest_item("movie", {"tmdb": 550, "tvdb": None}),
+        ]
+        mock_get.return_value = mock_response
+
+        url = "https://trakt.tv/users/johndoe/favorites"
+        items = trakt_instance.get_all_items_for_url(
+            "movie", {"max_items_per_list": 100, "lists": [url]}
+        )
+
+        assert 550 in items
+        assert items[550]["list"] == url
+
+    @patch("app.modules.trakt.requests.get")
+    def test_favorites_shows_use_tvdb_key(self, mock_get, trakt_instance_and_mock):
+        trakt_instance, _ = trakt_instance_and_mock
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            self._rest_item("show", {"tmdb": 1399, "tvdb": 121361}),
+        ]
+        mock_get.return_value = mock_response
+
+        items = trakt_instance.get_all_items_for_url(
+            "show",
+            {"lists": ["https://trakt.tv/users/johndoe/favorites"]},
+        )
+
+        assert 121361 in items
+        args, _ = mock_get.call_args
+        assert args[0].endswith("/favorites/shows")
+
+    @patch("app.modules.trakt.requests.get")
+    def test_favorites_http_error_does_not_crash(
+        self, mock_get, trakt_instance_and_mock
+    ):
+        """A REST failure is handled like any other list fetch failure."""
+        trakt_instance, _ = trakt_instance_and_mock
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("404 Not Found")
+        mock_get.return_value = mock_response
+
+        result = trakt_instance._fetch_list_items(
+            "movie", "johndoe", "favorites", None, 100
+        )
+
+        assert result == []


### PR DESCRIPTION
Fixes #27

- Favorites URLs parsed correctly but the fetch path was a stub that logged "Traktpy does not support favorites" and returned an empty list, so the exclusion silently protected nothing
- The pinned trakt.py 4.4.0 predates Trakt's favorites API (`GET /users/{id}/favorites/{type}` is a distinct top-level endpoint that cannot be routed through `users/*/lists/*`), so favorites are now fetched with a direct REST call using the configured client id (no OAuth needed for public profiles)
- REST items are wrapped in a small adapter exposing the same `get_key()` interface as trakt.py objects, so the existing processing pipeline works unchanged and fetch failures flow through the same error handling as every other list type
- Docs updated: favorites documented as supported (public profile required), limitation note removed
- Tests cover the REST call shape, movie/show key mapping, end-to-end exclusion population, and error handling