### PR TITLE
fix(leaving_soon): stop resetting the death-row clock so items actually get deleted

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -968,14 +968,28 @@ class Deleterr:
             preserve_plex_items=foreign_plex_items,
         )
 
-        # Record tagged timestamps for duration enforcement
+        # Re-read what actually made it onto the death row in Plex. The collection /
+        # label add can fail (e.g. Plex rejects a batch add with 400), and a failed
+        # add must NOT be recorded as tagged - otherwise state claims an item is on
+        # death row while Plex shows it empty, the duration clock is reset every run,
+        # and nothing is ever deleted. Plex is the source of truth here.
+        current_death_row = self._get_death_row_items(library, plex_library)
+        actually_tagged_keys = {item.ratingKey for item in current_death_row}
+
+        # Record tagged timestamps for duration enforcement (only for items that
+        # genuinely landed on death row in Plex).
         tagged_items = {}
+        failed_to_tag = 0
         if preview:
             now_iso = datetime.now().isoformat()
             for i, item in enumerate(preview):
                 plex_item = resolved_plex_items[i] if i < len(resolved_plex_items) else None
-                if plex_item:
+                if plex_item is None:
+                    continue
+                if plex_item.ratingKey in actually_tagged_keys:
                     tagged_items[str(plex_item.ratingKey)] = now_iso
+                else:
+                    failed_to_tag += 1
 
             if tagged_items:
                 self.state_manager.set_tagged_dates(library_name, tagged_items)
@@ -984,22 +998,37 @@ class Deleterr:
                     len(tagged_items),
                     library_name,
                 )
+            if failed_to_tag:
+                logger.warning(
+                    "%d item(s) for library '%s' could not be tagged into the leaving_soon "
+                    "collection/labels in Plex and were NOT recorded as tagged - they will be "
+                    "retried next run (see the Plex API warnings above)",
+                    failed_to_tag,
+                    library_name,
+                )
 
-        # Clean up state entries for items no longer in collection
-        # (handles items removed manually from the collection)
-        current_death_row = self._get_death_row_items(library, plex_library)
-        active_keys = {item.ratingKey for item in current_death_row}
-        # Also include the items we just tagged
-        for plex_item in resolved_plex_items:
-            if plex_item:
-                active_keys.add(plex_item.ratingKey)
+        # Clean up stale state entries (items removed from the collection/labels).
+        # active_keys = what is actually tagged in Plex now + items that were on death
+        # row before this entry ran (siblings sharing the same Plex library name).
+        active_keys = set(actually_tagged_keys)
         # Preserve state for items that were on death row before this library entry
         # processed them. This prevents a library entry from wiping state that belongs
         # to another library entry sharing the same Plex library name.
         if death_row_plex_items:
             for item in death_row_plex_items:
                 active_keys.add(item.ratingKey)
-        self.state_manager.cleanup_library(library_name, active_keys)
+        # Never clean up with an empty active set: state is keyed by Plex library name,
+        # so an entry that tagged nothing this run (e.g. the daily half of a split
+        # "TV Shows" library) would otherwise wipe a sibling entry's timestamps and
+        # reset its duration clock every run.
+        if active_keys:
+            self.state_manager.cleanup_library(library_name, active_keys)
+        else:
+            logger.debug(
+                "Skipping leaving_soon state cleanup for library '%s' - nothing is tagged "
+                "this run (avoids wiping a sibling entry's shared state)",
+                library_name,
+            )
 
         # Determine which items to notify about
         if not self.notifications.is_leaving_soon_enabled():

--- a/app/modules/plex.py
+++ b/app/modules/plex.py
@@ -119,12 +119,15 @@ class PlexMediaServer(BaseMediaServer):
                 "The collection will still work but won't show the deletion date."
             )
 
-    def set_collection_items(self, collection: Any, items: list) -> None:
+    def set_collection_items(self, collection: Any, items: list) -> list:
         """Replace collection contents with given items.
 
         Args:
             collection: The Plex collection.
             items: List of Plex media items to set in the collection.
+
+        Returns:
+            The list of items that were successfully added to the collection.
         """
         # Get current items in collection
         try:
@@ -142,15 +145,39 @@ class PlexMediaServer(BaseMediaServer):
                     "Some items may remain in the collection."
                 )
 
-        # Add new items
-        if items:
+        if not items:
+            return []
+
+        # Try a single batch add first. Some Plex servers reject the batch add-items
+        # URI (e.g. a 400 on a long multi-id request), so fall back to adding items
+        # one at a time rather than losing the whole set. Return the items that made
+        # it in so the caller only records genuinely-tagged items in state.
+        try:
+            collection.addItems(items)
+            return list(items)
+        except Exception as e:
+            logger.warning(
+                f"Batch add of {len(items)} items to collection '{collection.title}' failed: {e}. "
+                "Retrying one item at a time."
+            )
+
+        added = []
+        for item in items:
             try:
-                collection.addItems(items)
+                collection.addItems([item])
+                added.append(item)
             except Exception as e:
                 logger.warning(
-                    f"Error adding {len(items)} items to collection '{collection.title}': {e}. "
-                    "Some items may be missing from the leaving_soon collection."
+                    f"Could not add '{getattr(item, 'title', 'Unknown')}' to collection "
+                    f"'{collection.title}': {e}."
                 )
+
+        if not added:
+            logger.error(
+                f"Failed to add any of {len(items)} items to collection '{collection.title}'. "
+                "The leaving_soon death row cannot progress until items can be tagged in Plex."
+            )
+        return added
 
     def add_label(self, item: Any, label: str) -> None:
         """Add a label to a Plex media item.

--- a/tests/modules/test_plex.py
+++ b/tests/modules/test_plex.py
@@ -151,6 +151,68 @@ class TestPlexMediaServerCollections:
         mock_collection.removeItems.assert_called_once_with(current_items)
         mock_collection.addItems.assert_not_called()
 
+    def test_set_collection_items_returns_added_on_success(self, plex_server):
+        """A successful batch add returns the full list of items."""
+        plex, _ = plex_server
+        mock_collection = MagicMock()
+        mock_collection.items.return_value = []
+        new_items = [MagicMock(), MagicMock()]
+
+        added = plex.set_collection_items(mock_collection, new_items)
+
+        assert added == new_items
+
+    def test_set_collection_items_falls_back_to_per_item_on_batch_failure(self, plex_server):
+        """If the batch add is rejected (e.g. Plex 400), fall back to per-item adds."""
+        plex, _ = plex_server
+        mock_collection = MagicMock()
+        mock_collection.items.return_value = []
+        item_a, item_b = MagicMock(), MagicMock()
+
+        def add_items_side_effect(items):
+            # Reject the multi-item batch (mirrors the Plex 400 on the batch URI),
+            # accept single-item adds.
+            if len(items) > 1:
+                raise Exception("(400) bad_request")
+
+        mock_collection.addItems.side_effect = add_items_side_effect
+
+        added = plex.set_collection_items(mock_collection, [item_a, item_b])
+
+        assert added == [item_a, item_b]
+        # One failed batch call + one successful call per item
+        assert mock_collection.addItems.call_count == 3
+
+    def test_set_collection_items_returns_only_successfully_added(self, plex_server):
+        """Per-item fallback returns only the items that were actually added."""
+        plex, _ = plex_server
+        mock_collection = MagicMock()
+        mock_collection.items.return_value = []
+        item_ok, item_bad = MagicMock(), MagicMock()
+
+        def add_items_side_effect(items):
+            if len(items) > 1:
+                raise Exception("(400) bad_request")  # batch fails
+            if items == [item_bad]:
+                raise Exception("(400) bad_request")  # this one keeps failing
+
+        mock_collection.addItems.side_effect = add_items_side_effect
+
+        added = plex.set_collection_items(mock_collection, [item_ok, item_bad])
+
+        assert added == [item_ok]
+
+    def test_set_collection_items_returns_empty_when_all_fail(self, plex_server):
+        """When nothing can be added, return an empty list (state must stay honest)."""
+        plex, _ = plex_server
+        mock_collection = MagicMock()
+        mock_collection.items.return_value = []
+        mock_collection.addItems.side_effect = Exception("(400) bad_request")
+
+        added = plex.set_collection_items(mock_collection, [MagicMock(), MagicMock()])
+
+        assert added == []
+
 
 class TestPlexMediaServerLabels:
     """Test label operations."""

--- a/tests/test_leaving_soon_duration.py
+++ b/tests/test_leaving_soon_duration.py
@@ -793,7 +793,8 @@ class TestNotificationDedup:
         # process_leaving_soon returns resolved plex items
         deleterr_instance.media_cleaner.process_leaving_soon.return_value = [plex_a, plex_b]
         deleterr_instance.media_server.get_library.return_value = MagicMock()
-        deleterr_instance._get_death_row_items = MagicMock(return_value=[])
+        # Items land on the death row in Plex (re-read source of truth for tagging)
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[plex_a, plex_b])
 
         with patch("app.media_cleaner.compute_deletion_date", return_value=None):
             deleterr_instance._process_library_leaving_soon(library, preview, "movie")
@@ -821,7 +822,8 @@ class TestNotificationDedup:
         plex_a = self._make_plex_item(100, "Movie A")
         deleterr_instance.media_cleaner.process_leaving_soon.return_value = [plex_a]
         deleterr_instance.media_server.get_library.return_value = MagicMock()
-        deleterr_instance._get_death_row_items = MagicMock(return_value=[])
+        # Item is on the death row in Plex, but was already tagged in a prior run
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[plex_a])
 
         # Simulate first run: record item in state
         deleterr_instance.state_manager.set_tagged_dates("Movies", {"100": "2026-03-01T00:00:00"})
@@ -848,7 +850,8 @@ class TestNotificationDedup:
         plex_c = self._make_plex_item(300, "Movie C")
         deleterr_instance.media_cleaner.process_leaving_soon.return_value = [plex_a, plex_c]
         deleterr_instance.media_server.get_library.return_value = MagicMock()
-        deleterr_instance._get_death_row_items = MagicMock(return_value=[])
+        # Both items land on the death row in Plex (re-read source of truth for tagging)
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[plex_a, plex_c])
 
         # Movie A was already tagged in state
         deleterr_instance.state_manager.set_tagged_dates("Movies", {"100": "2026-03-01T00:00:00"})
@@ -863,6 +866,72 @@ class TestNotificationDedup:
         # Only Movie C should be in the notified items
         assert len(notified_items) == 1
         assert notified_items[0].title == "Movie C"
+
+    def test_failed_plex_add_not_recorded_in_state(self, deleterr_instance):
+        """If the Plex add fails (nothing lands on death row), the item is NOT recorded
+        in state and no notification fires - state must mirror Plex (issue #300)."""
+        library = {
+            "name": "Movies",
+            "radarr": "Radarr",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}, "duration": "7d"},
+        }
+        preview = [{"title": "Movie A", "tmdbId": 1, "year": 2024, "sizeOnDisk": 1000}]
+        plex_a = self._make_plex_item(100, "Movie A")
+        deleterr_instance.media_cleaner.process_leaving_soon.return_value = [plex_a]
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+        # Nothing landed on the death row in Plex (the add failed)
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[])
+
+        with patch("app.media_cleaner.compute_deletion_date", return_value=None):
+            deleterr_instance._process_library_leaving_soon(library, preview, "movie")
+
+        assert deleterr_instance.state_manager.get_tagged_dates("Movies") == {}
+        assert not deleterr_instance.notifications.send_leaving_soon.called
+
+    def test_partial_plex_add_records_only_landed_items(self, deleterr_instance):
+        """Only items that actually landed on the Plex death row are recorded (issue #300)."""
+        library = {
+            "name": "Movies",
+            "radarr": "Radarr",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}, "duration": "7d"},
+        }
+        preview = [
+            {"title": "Movie A", "tmdbId": 1, "year": 2024, "sizeOnDisk": 1000},
+            {"title": "Movie B", "tmdbId": 2, "year": 2023, "sizeOnDisk": 2000},
+        ]
+        plex_a = self._make_plex_item(100, "Movie A")
+        plex_b = self._make_plex_item(200, "Movie B")
+        deleterr_instance.media_cleaner.process_leaving_soon.return_value = [plex_a, plex_b]
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+        # Only Movie A landed in Plex
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[plex_a])
+
+        with patch("app.media_cleaner.compute_deletion_date", return_value=None):
+            deleterr_instance._process_library_leaving_soon(library, preview, "movie")
+
+        assert set(deleterr_instance.state_manager.get_tagged_dates("Movies").keys()) == {"100"}
+
+    def test_cleanup_does_not_wipe_sibling_state_when_nothing_tagged(self, deleterr_instance):
+        """An entry that tags nothing must not wipe a sibling entry's timestamps in the
+        shared, name-keyed state bucket (issue #301 - the shifting removal date)."""
+        library = {
+            "name": "TV Shows",
+            "sonarr": "Sonarr",
+            "leaving_soon": {"collection": {"name": "Leaving Soon"}, "duration": "7d"},
+        }
+        # A sibling "TV Shows" entry tagged item 999 on a previous run.
+        deleterr_instance.state_manager.set_tagged_dates("TV Shows", {"999": "2026-03-01T00:00:00"})
+        # This entry has no candidates and nothing on its death-row read.
+        deleterr_instance.media_cleaner.process_leaving_soon.return_value = []
+        deleterr_instance.media_server.get_library.return_value = MagicMock()
+        deleterr_instance._get_death_row_items = MagicMock(return_value=[])
+
+        with patch("app.media_cleaner.compute_deletion_date", return_value=None):
+            deleterr_instance._process_library_leaving_soon(library, [], "show")
+
+        assert deleterr_instance.state_manager.get_tagged_dates("TV Shows") == {
+            "999": "2026-03-01T00:00:00"
+        }
 
     def test_no_duration_always_notifies(self, deleterr_instance):
         """Without duration config, all items are notified every run."""


### PR DESCRIPTION
## What this fixes

`leaving_soon` was silently deleting nothing. On every run, for every library, the log showed:

```
No items in leaving_soon (first run or empty death row)
Processing leaving_soon for library 'X': N items to tag
WARNING: Error adding N items to collection 'Leaving Soon': (400) bad_request ... Some items may be missing
```

and the run summary reported `Total items deleted: 0` run after run.

Two compounding bugs (#300, #301):

1. **The collection add fails and the failure is swallowed, but state is recorded anyway.** `set_collection_items` caught the `addItems` exception, logged a warning, and returned. `_process_library_leaving_soon` then recorded `tagged_at` for every preview item regardless. So state claimed items were on death row while Plex showed the collection empty. Next run, `_get_death_row_items` read an empty collection → "empty death row" → re-tagged from scratch → the duration clock reset every run → nothing ever aged past `duration`.

2. **Two library entries sharing a Plex name wipe each other's state.** State is keyed by Plex library name, so a split "TV Shows" library (two entries by `series_type`) shares one bucket. The entry with no candidates called `cleanup_library` with an empty active set and deleted the sibling entry's timestamps, which then got re-stamped to "now" - the visible symptom being a removal date that marches forward one day per run (July 14 → 15 → 16 → 17 ...).

## Changes

- **`set_collection_items`**: falls back to per-item adds when the batch add is rejected (a long multi-id batch URI is a plausible 400 cause), and returns the items that actually landed.
- **`_process_library_leaving_soon`**: re-reads the death row from Plex after tagging and records `tagged_at` only for items that genuinely landed, warning on the rest. State can no longer diverge from Plex, so the duration clock is honest.
- **Cleanup guard**: skips `cleanup_library` when nothing is tagged this run, so an entry that tags nothing can never wipe a sibling entry's timestamps in the shared, name-keyed bucket.

## Tests

- `set_collection_items`: returns added items on success; per-item fallback on batch failure; returns only successfully-added items; returns empty when all adds fail.
- `_process_library_leaving_soon`: a failed Plex add is not recorded in state and sends no notification; a partial add records only the landed items; an entry that tags nothing does not wipe a sibling's state.

Full suite green (853 passed).

Fixes #300
Fixes #301
