### PR TITLE
feat(on-demand): add --free-up emergency cleanup mode

### DIFF
--- a/app/deleterr.py
+++ b/app/deleterr.py
@@ -1293,6 +1293,29 @@ def main():
         action="store_true",
         help="Force single run mode (overrides scheduler config)",
     )
+    parser.add_argument(
+        "--free-up",
+        dest="free_up",
+        default=None,
+        metavar="SIZE",
+        help=(
+            "On-demand emergency cleanup: delete across ALL libraries until every "
+            "disk has SIZE free, then stop (e.g. '1TB'). Forces a single immediate "
+            "run and bypasses the leaving_soon grace period."
+        ),
+    )
+    parser.add_argument(
+        "--free-up-path",
+        dest="free_up_path",
+        default=None,
+        metavar="PATH",
+        help="Restrict --free-up to a single mount/root folder (e.g. '/data/media')",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --free-up, preview what would be deleted without deleting anything",
+    )
 
     args, unknown = parser.parse_known_args()
 
@@ -1311,6 +1334,37 @@ def main():
         print(providers)
         logger.info("# of Trakt Providers: " + str(len(providers)))
 
+        return
+
+    # On-demand emergency cleanup (--free-up): single immediate run across all
+    # libraries until each disk hits the free-space target, then stop.
+    if args.free_up:
+        from app.on_demand import OnDemandCleaner
+        from app.utils import parse_size_to_bytes
+
+        try:
+            target_bytes = parse_size_to_bytes(args.free_up)
+        except (ValueError, IndexError):
+            logger.error(
+                "Invalid --free-up size '%s'. Use a value like '1TB', '500GB' or '750MB' "
+                "(uppercase unit).",
+                args.free_up,
+            )
+            sys.exit(1)
+
+        if args.dry_run:
+            config.settings["dry_run"] = True
+
+        # This is an explicit emergency action. If the scheduler daemon holds the
+        # instance lock, proceed anyway rather than blocking - the user asked for
+        # space now. We don't hold the lock ourselves (single short-lived run).
+        if not acquire_instance_lock():
+            logger.warning(
+                "Another deleterr instance is running, but --free-up is an emergency "
+                "action - proceeding anyway."
+            )
+
+        OnDemandCleaner(config).run(target_bytes, free_up_path=args.free_up_path)
         return
 
     # Determine run mode

--- a/app/media_cleaner.py
+++ b/app/media_cleaner.py
@@ -484,6 +484,52 @@ class MediaCleaner:
                == library.get("series_type", DEFAULT_SONARR_SERIES_TYPE)
         ]
 
+    def get_ordered_candidates(self, library, media_instance, media_type, all_data=None):
+        """
+        Return media items that currently match this library's deletion rules,
+        in the order the library's ``sort`` config produces.
+
+        Reuses :meth:`process_library_rules` unchanged, so exclusions, genres,
+        Trakt/mdblist lists, ``last_watched_threshold`` and ``added_at_threshold``
+        are all honored. Neither ``max_actions_per_run`` nor the per-library disk
+        gate is applied - the caller (on-demand cleanup) decides how many to consume.
+
+        Args:
+            library: Library configuration dict
+            media_instance: Radarr or Sonarr instance
+            media_type: 'movie' or 'show'
+            all_data: Unfiltered Sonarr series list (shows only). Fetched from the
+                instance when omitted.
+
+        Returns:
+            List of media dicts in the library's sort order. Each item carries
+            ``path`` and its size (``sizeOnDisk`` for movies, ``statistics.sizeOnDisk``
+            for shows), which on-demand cleanup uses for disk mapping and accounting.
+        """
+        plex_library = self.get_plex_library(library)
+
+        if media_type == "movie":
+            trakt_items = self.get_trakt_items("movie", library)
+            mdblist_items = self.get_mdblist_items("movie", library)
+            activity = self.get_movie_activity(library, plex_library)
+            media_data = media_instance.get_movies()
+            instance_kwargs = {"radarr_instance": media_instance}
+        else:
+            if all_data is None:
+                all_data = media_instance.get_series()
+            media_data = self.filter_shows(library, all_data)
+            trakt_items = self.get_trakt_items("show", library)
+            mdblist_items = self.get_mdblist_items("show", library)
+            activity = self.get_show_activity(library, plex_library)
+            instance_kwargs = {"sonarr_instance": media_instance}
+
+        return list(
+            self.process_library_rules(
+                library, plex_library, media_data, activity, trakt_items,
+                mdblist_items=mdblist_items, **instance_kwargs
+            )
+        )
+
     def process_library(self, library, sonarr_instance, unfiltered_all_show_data):
         """
         Process a Sonarr library.

--- a/app/on_demand.py
+++ b/app/on_demand.py
@@ -1,0 +1,484 @@
+# encoding: utf-8
+"""
+On-demand emergency cleanup mode (``--free-up``).
+
+Sweeps across *all* configured Radarr and Sonarr libraries at once and deletes
+actionable content immediately until every targeted disk has a requested amount
+of free space, then stops.
+
+This is deliberately different from the per-library ``disk_size_threshold`` gate
+(``library_meets_disk_space_threshold``): that is a one-shot on/off gate evaluated
+per library ("skip this library if free space > threshold"). On-demand mode is
+cross-library, drives toward a free-space target per disk, deletes incrementally,
+and stops the instant the target is met.
+
+Protections are fully honored - it reuses :meth:`MediaCleaner.get_ordered_candidates`
+(exclusions, genres, Trakt/mdblist, watch/added thresholds, each library's sort).
+Only ``max_actions_per_run`` and the per-library disk gate are overridden, and the
+Leaving Soon / death-row grace period is bypassed (immediate hard delete).
+"""
+
+from datetime import datetime
+
+from app import logger
+from app.media_cleaner import ConfigurationError, MediaCleaner
+from app.modules.notifications import NotificationManager, RunResult, DeletedItem
+from app.modules.plex import PlexMediaServer
+from app.modules.radarr import DRadarr
+from app.modules.sonarr import DSonarr
+from app.modules.tautulli import TautulliApiError
+from app.utils import print_readable_freed_space
+
+# Re-query the arr's real free space after this many deletions to correct for
+# Radarr/Sonarr's lagging freeSpace (we optimistically sum sizeOnDisk between
+# re-queries, which is fast but drifts).
+REQUERY_EVERY_N_DELETIONS = 10
+
+
+def normalize_path(path):
+    """Strip a trailing slash so path prefix comparisons are segment-accurate."""
+    if not path:
+        return path
+    return path.rstrip("/") or "/"
+
+
+def is_subpath(path, base):
+    """
+    Return True if ``path`` is ``base`` itself or lives under it, comparing on
+    path-segment boundaries so ``/data`` is not treated as a prefix of ``/data2``.
+    """
+    if not path or not base:
+        return False
+    path = normalize_path(path)
+    base = normalize_path(base)
+    if base == "/":
+        return True
+    return path == base or path.startswith(base + "/")
+
+
+def map_path_to_disk(item_path, disk_paths):
+    """
+    Map a media item's path to the disk it lives on by longest-prefix match.
+
+    Args:
+        item_path: The Radarr/Sonarr folder path of a media item.
+        disk_paths: Iterable of candidate disk (mount/root-folder) paths.
+
+    Returns:
+        The disk path that is the longest prefix of ``item_path``, or None if the
+        item does not fall under any of the given disks.
+    """
+    if not item_path:
+        return None
+    best = None
+    for disk_path in disk_paths:
+        if is_subpath(item_path, disk_path):
+            if best is None or len(normalize_path(disk_path)) > len(normalize_path(best)):
+                best = disk_path
+    return best
+
+
+def item_size(item, media_type):
+    """Return the on-disk size in bytes for a Radarr/Sonarr media item."""
+    if media_type == "movie":
+        return item.get("sizeOnDisk", 0) or 0
+    return item.get("statistics", {}).get("sizeOnDisk", 0) or 0
+
+
+class OnDemandCleaner:
+    """
+    Emergency cross-library cleanup that frees disks toward a target and stops.
+
+    Organized per disk (a Radarr mount and a Sonarr mount can be the same physical
+    disk, and the target is per-disk): build under-target disks, gather ordered
+    candidates from every library, map each candidate to its disk, then round-robin
+    delete across the libraries on each disk - one item at a time, re-checking the
+    target after every deletion - until the target is met or candidates run out.
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self.is_dry_run = config.settings.get("dry_run", True)
+
+        ssl_verify = config.settings.get("ssl_verify", False)
+        self.media_server = PlexMediaServer(
+            config.settings.get("plex").get("url"),
+            config.settings.get("plex").get("token"),
+            ssl_verify=ssl_verify,
+        )
+        self.media_cleaner = MediaCleaner(config, media_server=self.media_server)
+        self.notifications = NotificationManager(config)
+        self.run_result = RunResult(
+            is_dry_run=self.is_dry_run,
+            start_time=datetime.now(),
+        )
+
+        self.sonarr = {
+            connection["name"]: DSonarr(connection["name"], connection["url"], connection["api_key"])
+            for connection in config.settings.get("sonarr", [])
+        }
+        self.radarr = {
+            connection["name"]: DRadarr(connection["name"], connection["url"], connection["api_key"])
+            for connection in config.settings.get("radarr", [])
+        }
+
+        self.libraries_processed = 0
+        self.libraries_failed = 0
+
+    # -- orchestration ---------------------------------------------------------
+
+    def run(self, target_bytes, free_up_path=None):
+        """
+        Free every targeted disk up to ``target_bytes`` of free space, then stop.
+
+        Args:
+            target_bytes: Desired free space per disk, in bytes.
+            free_up_path: Optional mount/root-folder to restrict cleanup to.
+        """
+        mode = "[DRY-RUN] " if self.is_dry_run else ""
+        logger.info(
+            "%sOn-demand cleanup: freeing every disk up to %s free%s",
+            mode,
+            print_readable_freed_space(target_bytes),
+            f" (restricted to '{free_up_path}')" if free_up_path else "",
+        )
+
+        disks = self._build_disk_targets(target_bytes, free_up_path)
+        if not disks:
+            logger.info("No targeted disk is below the requested free-space target - nothing to do")
+            self.run_result.end_time = datetime.now()
+            return
+
+        self._gather_candidates(disks, target_bytes)
+
+        for disk in disks:
+            self._process_disk(disk)
+
+        self.run_result.end_time = datetime.now()
+        self._log_summary(disks, target_bytes)
+        self._send_notification()
+
+    # -- step 1: disk targets --------------------------------------------------
+
+    def _build_disk_targets(self, target_bytes, free_up_path):
+        """
+        Build the list of disks that are below the free-space target.
+
+        Queries ``get_disk_space()`` on every configured instance, dedupes folders
+        that are the same physical mount (by path), applies the optional
+        ``free_up_path`` filter, and keeps only folders whose free space is below
+        the target.
+        """
+        disks = {}
+        for instances in (self.radarr, self.sonarr):
+            for name, instance in instances.items():
+                try:
+                    disk_space = instance.get_disk_space()
+                except Exception as e:
+                    logger.error(f"Failed to get disk space from instance '{name}': {e}")
+                    continue
+
+                for folder in disk_space or []:
+                    path = folder.get("path")
+                    if path is None:
+                        continue
+                    if free_up_path and not (
+                        is_subpath(path, free_up_path) or is_subpath(free_up_path, path)
+                    ):
+                        continue
+                    if path in disks:
+                        # Same physical mount already recorded (e.g. reported by
+                        # both a Radarr and a Sonarr instance) - don't double-count.
+                        continue
+                    disks[path] = {
+                        "path": path,
+                        "free_space": folder.get("freeSpace", 0) or 0,
+                        "instance": instance,
+                        "libraries": [],
+                    }
+
+        if not disks:
+            logger.warning(
+                "No disks matched%s - check that the instances are reachable and the "
+                "path (if given) matches a Radarr/Sonarr root folder",
+                f" '{free_up_path}'" if free_up_path else "",
+            )
+            return []
+
+        targets = []
+        for path, disk in disks.items():
+            if disk["free_space"] < target_bytes:
+                disk["target"] = target_bytes
+                disk["deficit"] = target_bytes - disk["free_space"]
+                disk["freed"] = 0
+                disk["final_free"] = disk["free_space"]
+                logger.info(
+                    "Disk '%s': %s free, need to free %s more",
+                    path,
+                    print_readable_freed_space(disk["free_space"]),
+                    print_readable_freed_space(disk["deficit"]),
+                )
+                targets.append(disk)
+            else:
+                logger.info(
+                    "Disk '%s' already has %s free (>= target) - skipping",
+                    path,
+                    print_readable_freed_space(disk["free_space"]),
+                )
+        return targets
+
+    # -- step 2: gather candidates ---------------------------------------------
+
+    def _resolve_library(self, library, series_cache):
+        """Resolve a library to its (instance, media_type, all_data)."""
+        radarr_name = library.get("radarr")
+        if radarr_name:
+            if radarr_name in self.radarr:
+                return self.radarr[radarr_name], "movie", None
+            logger.warning(
+                "Library '%s' references unknown radarr instance '%s' - skipping",
+                library.get("name", "Unknown"), radarr_name,
+            )
+            return None, None, None
+
+        sonarr_name = library.get("sonarr")
+        if sonarr_name:
+            if sonarr_name in self.sonarr:
+                instance = self.sonarr[sonarr_name]
+                if sonarr_name not in series_cache:
+                    series_cache[sonarr_name] = instance.get_series()
+                return instance, "show", series_cache[sonarr_name]
+            logger.warning(
+                "Library '%s' references unknown sonarr instance '%s' - skipping",
+                library.get("name", "Unknown"), sonarr_name,
+            )
+            return None, None, None
+
+        return None, None, None
+
+    def _gather_candidates(self, disks, target_bytes):
+        """
+        Gather ordered deletion candidates from every library and bucket them onto
+        the disk each item lives on, preserving library (config) order per disk.
+        """
+        disk_by_path = {disk["path"]: disk for disk in disks}
+        disk_paths = list(disk_by_path.keys())
+        series_cache = {}
+
+        for library in self.config.settings.get("libraries", []):
+            instance, media_type, all_data = self._resolve_library(library, series_cache)
+            if instance is None:
+                continue
+
+            library_name = library.get("name", "Unknown")
+            try:
+                candidates = self.media_cleaner.get_ordered_candidates(
+                    library, instance, media_type, all_data
+                )
+            except (ConfigurationError, TautulliApiError) as e:
+                logger.error(f"Failed to gather candidates for library '{library_name}': {e}")
+                self.libraries_failed += 1
+                continue
+            except Exception as e:
+                logger.error(f"Unexpected error gathering candidates for library '{library_name}': {e}")
+                self.libraries_failed += 1
+                continue
+
+            self.libraries_processed += 1
+
+            queue_by_disk = {}
+            unmapped = 0
+            for item in candidates:
+                disk_path = map_path_to_disk(item.get("path"), disk_paths)
+                if disk_path is None:
+                    unmapped += 1
+                    continue
+                queue_by_disk.setdefault(disk_path, []).append(item)
+
+            for disk_path, items in queue_by_disk.items():
+                disk_by_path[disk_path]["libraries"].append({
+                    "library": library,
+                    "instance": instance,
+                    "media_type": media_type,
+                    "queue": items,
+                })
+
+            mapped = sum(len(v) for v in queue_by_disk.values())
+            logger.info(
+                "Library '%s': %d candidate(s) on targeted disks%s",
+                library_name,
+                mapped,
+                f" ({unmapped} on other disks)" if unmapped else "",
+            )
+
+    # -- step 3: round-robin delete per disk -----------------------------------
+
+    def _process_disk(self, disk):
+        """
+        Round-robin across the libraries on a disk, deleting one candidate at a
+        time and re-checking the target after each deletion, until the target is
+        met or every candidate pool is exhausted.
+        """
+        target = disk["target"]
+        path = disk["path"]
+        free_space = disk["free_space"]
+        freed = 0
+        since_requery = 0
+
+        active = [q for q in disk["libraries"] if q["queue"]]
+        if not active:
+            logger.warning(
+                "Disk '%s' is below target but has no actionable candidates "
+                "(all protected or on other disks)",
+                path,
+            )
+            disk["final_free"] = free_space
+            disk["freed"] = 0
+            return
+
+        logger.info("Freeing disk '%s' (round-robin across %d librar%s)",
+                    path, len(active), "y" if len(active) == 1 else "ies")
+
+        while free_space < target and active:
+            for q in active:
+                if free_space >= target:
+                    break
+                if not q["queue"]:
+                    continue
+                item = q["queue"].pop(0)
+                size = self._delete(q, item)
+                if size is None:
+                    # Deletion skipped (e.g. episode file in use) - don't count it.
+                    continue
+                freed += size
+                free_space += size
+                since_requery += 1
+
+                if not self.is_dry_run and since_requery >= REQUERY_EVERY_N_DELETIONS:
+                    since_requery = 0
+                    requeried = self._requery_free_space(disk)
+                    if requeried is not None:
+                        free_space = requeried
+
+            active = [q for q in active if q["queue"]]
+
+        disk["freed"] = freed
+        disk["final_free"] = free_space
+
+        if free_space >= target:
+            logger.info(
+                "Disk '%s': target met - freed %s (now %s free)",
+                path,
+                print_readable_freed_space(freed),
+                print_readable_freed_space(free_space),
+            )
+        else:
+            logger.warning(
+                "Disk '%s': ran out of candidates before reaching target - "
+                "freed %s of %s needed",
+                path,
+                print_readable_freed_space(freed),
+                print_readable_freed_space(disk["deficit"]),
+            )
+
+    def _delete(self, queue_entry, item):
+        """
+        Delete (or, in dry-run, simulate deleting) a single media item.
+
+        Returns:
+            The bytes freed, or None if the deletion was skipped/failed and must
+            not count toward the target.
+        """
+        library = queue_entry["library"]
+        instance = queue_entry["instance"]
+        media_type = queue_entry["media_type"]
+        title = item.get("title", "Unknown")
+        size = item_size(item, media_type)
+
+        logger.log_deletion(
+            title=title,
+            size_bytes=size,
+            media_type=media_type,
+            is_dry_run=self.is_dry_run,
+        )
+
+        if not self.is_dry_run:
+            try:
+                if media_type == "movie":
+                    self.media_cleaner.delete_movie_if_allowed(library, instance, item)
+                else:
+                    if not self.media_cleaner.delete_series(instance, item):
+                        # e.g. an episode file is in use - skip and don't count it.
+                        logger.warning(
+                            f"Skipped '{title}' (deletion could not complete) - "
+                            "not counting toward the free-space target"
+                        )
+                        return None
+                    self.media_cleaner._update_seerr_status(library, item, "tv")
+            except Exception as e:
+                logger.error(f"Failed to delete '{title}': {e}")
+                return None
+
+        instance_name = library.get("radarr") or library.get("sonarr") or "Unknown"
+        library_name = library.get("name", "Unknown")
+        if media_type == "movie":
+            self.run_result.add_deleted(DeletedItem.from_radarr(item, library_name, instance_name))
+        else:
+            self.run_result.add_deleted(DeletedItem.from_sonarr(item, library_name, instance_name))
+
+        return size
+
+    def _requery_free_space(self, disk):
+        """Re-query an arr for the current free space of this disk's path."""
+        instance = disk["instance"]
+        try:
+            for folder in instance.get_disk_space() or []:
+                if folder.get("path") == disk["path"]:
+                    return folder.get("freeSpace", disk["free_space"])
+        except Exception as e:
+            logger.debug(f"Could not re-query free space for '{disk['path']}': {e}")
+        return None
+
+    # -- step 4: reporting -----------------------------------------------------
+
+    def _log_summary(self, disks, target_bytes):
+        separator = "=" * 60
+        logger.info(separator)
+        logger.info("ON-DEMAND CLEANUP SUMMARY")
+        logger.info(separator)
+
+        if self.is_dry_run:
+            logger.info("[DRY-RUN MODE] No changes were made")
+
+        if self.run_result.duration_seconds is not None:
+            logger.info(f"Duration: {logger.format_duration(self.run_result.duration_seconds)}")
+
+        logger.info(f"Libraries processed: {self.libraries_processed}")
+        if self.libraries_failed > 0:
+            logger.info(f"Libraries failed: {self.libraries_failed}")
+
+        logger.info("-" * 40)
+        logger.info("Per-Disk Results (target: %s free):", print_readable_freed_space(target_bytes))
+        for disk in disks:
+            met = disk["final_free"] >= target_bytes
+            logger.info(
+                "  %s %s: freed %s, now %s free",
+                "[met]" if met else "[unmet]",
+                disk["path"],
+                print_readable_freed_space(disk.get("freed", 0)),
+                print_readable_freed_space(disk.get("final_free", disk["free_space"])),
+            )
+
+        logger.info("-" * 40)
+        logger.info(f"Total items deleted: {len(self.run_result.deleted_items)}")
+        total_freed = self.run_result.total_freed_bytes
+        if total_freed > 0:
+            logger.info(f"Total space freed: {print_readable_freed_space(total_freed)}")
+        logger.info(separator)
+
+    def _send_notification(self):
+        if self.notifications.is_enabled():
+            try:
+                self.notifications.send_run_summary(self.run_result)
+            except Exception as e:
+                logger.error(f"Failed to send notification: {e}")

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -407,6 +407,52 @@ scheduler:
 
 ---
 
+## On-Demand Emergency Cleanup (`--free-up`)
+
+An ad-hoc emergency mode for when you need space *now*: it sweeps across **all**
+libraries (Radarr and Sonarr together) and deletes actionable content immediately
+until each targeted disk has the requested amount of free space, then stops.
+
+```bash
+python -m app --free-up 1TB                             # free every disk up to 1TB free, then stop
+python -m app --free-up 1TB --free-up-path /data/media  # restrict to one mount/root folder
+python -m app --free-up 1TB --dry-run                   # preview only, delete nothing
+```
+
+**How it differs from `disk_size_threshold`.** The per-library disk threshold is a
+one-shot on/off gate ("skip this library if free space is already above X").
+`--free-up` is cross-library, drives toward a free-space **target per disk**,
+deletes **incrementally**, and stops the instant the target is met.
+
+**Behavior:**
+
+- **Per disk.** The target is checked per Radarr/Sonarr root-folder path (per
+  mount). Folders that are the same physical mount are deduped so free space is
+  never double-counted.
+- **Immediate hard delete.** Bypasses the Leaving Soon grace period entirely and
+  deletes right away.
+- **Protections honored.** Exclusions, genres, Trakt/mdblist lists,
+  `last_watched_threshold` and `added_at_threshold` are all still respected, and
+  each library's `sort` order is used to pick what goes first. Only
+  `max_actions_per_run` and the per-library disk gate are overridden.
+- **Round-robin.** For each under-target disk it rotates through the libraries on
+  that disk (config order), deleting one candidate at a time and re-checking the
+  target after each deletion, until the target is met or the candidates run out
+  (in which case it warns how much of the needed space it managed to free).
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--free-up <SIZE>` | Target free space per disk (e.g. `1TB`, `500GB`, `750MB`). Implies a single immediate run. |
+| `--free-up-path <PATH>` | Restrict cleanup to a single mount/root folder. |
+| `--dry-run` | Simulate the run and log what would be freed per disk without deleting anything. |
+
+> `--free-up` is an emergency action. If the built-in scheduler is mid-run, it
+> proceeds anyway rather than waiting for the lock.
+
+---
+
 ## Notifications
 
 Optional. Configure notification providers to receive alerts when Deleterr deletes media.

--- a/tests/modules/test_on_demand.py
+++ b/tests/modules/test_on_demand.py
@@ -1,0 +1,349 @@
+"""
+Unit tests for the on-demand emergency cleanup mode (``--free-up``).
+
+These verify the cross-library, per-disk, round-robin algorithm in
+``app/on_demand.py`` in isolation: disk target building, path->disk mapping,
+candidate gathering order, stopping exactly at the target, per-disk accounting,
+round-robin across libraries, dry-run behavior, drift correction, and graceful
+handling of an unreachable target.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.on_demand import (
+    OnDemandCleaner,
+    is_subpath,
+    map_path_to_disk,
+    item_size,
+    normalize_path,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+class TestPathHelpers:
+    def test_normalize_path_strips_trailing_slash(self):
+        assert normalize_path("/data/") == "/data"
+        assert normalize_path("/data") == "/data"
+        assert normalize_path("/") == "/"
+
+    def test_is_subpath_matches_on_segment_boundaries(self):
+        assert is_subpath("/data/media/x", "/data") is True
+        assert is_subpath("/data", "/data") is True
+        # /data2 must NOT be treated as living under /data
+        assert is_subpath("/data2/x", "/data") is False
+        assert is_subpath("/other", "/data") is False
+
+    def test_is_subpath_root_matches_everything(self):
+        assert is_subpath("/anything/here", "/") is True
+
+    def test_map_path_to_disk_longest_prefix(self):
+        disks = ["/data", "/data/media"]
+        assert map_path_to_disk("/data/media/movies/X", disks) == "/data/media"
+        assert map_path_to_disk("/data/other/Y", disks) == "/data"
+        assert map_path_to_disk("/mnt/z", disks) is None
+        assert map_path_to_disk(None, disks) is None
+
+    def test_item_size(self):
+        assert item_size({"sizeOnDisk": 500}, "movie") == 500
+        assert item_size({"statistics": {"sizeOnDisk": 700}}, "show") == 700
+        assert item_size({}, "movie") == 0
+        assert item_size({}, "show") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Cleaner fixture (heavy deps mocked out)
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def cleaner():
+    """An OnDemandCleaner with all external dependencies mocked."""
+    config = MagicMock()
+    config.settings = {
+        "dry_run": False,
+        "libraries": [],
+        "sonarr": [],
+        "radarr": [],
+        "plex": {"url": "http://plex", "token": "t"},
+    }
+
+    with patch("app.on_demand.PlexMediaServer", return_value=MagicMock()), \
+         patch("app.on_demand.MediaCleaner", return_value=MagicMock()), \
+         patch("app.on_demand.NotificationManager", return_value=MagicMock()):
+        c = OnDemandCleaner(config)
+
+    c.notifications.is_enabled.return_value = False
+    return c
+
+
+def _movie(title, path, size):
+    return {"title": title, "path": path, "sizeOnDisk": size, "year": 2000}
+
+
+def _library_queue(name, instance_key, media_type, items, cleaner):
+    """Build a per-library queue entry as _gather_candidates would."""
+    library = {"name": name, ("radarr" if media_type == "movie" else "sonarr"): instance_key}
+    return {
+        "library": library,
+        "instance": MagicMock(),
+        "media_type": media_type,
+        "queue": list(items),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Disk target building
+# --------------------------------------------------------------------------- #
+
+class TestBuildDiskTargets:
+    def test_keeps_under_target_and_dedupes_same_mount(self, cleaner):
+        radarr = MagicMock()
+        radarr.get_disk_space.return_value = [
+            {"path": "/data", "freeSpace": 100},
+            {"path": "/movies", "freeSpace": 5000},
+        ]
+        sonarr = MagicMock()
+        # Same physical mount /data reported again - must be deduped.
+        sonarr.get_disk_space.return_value = [{"path": "/data", "freeSpace": 100}]
+        cleaner.radarr = {"R": radarr}
+        cleaner.sonarr = {"S": sonarr}
+
+        disks = cleaner._build_disk_targets(target_bytes=1000, free_up_path=None)
+
+        assert [d["path"] for d in disks] == ["/data"]  # /movies is above target
+        assert disks[0]["deficit"] == 900
+        # First instance that reported /data wins (dedupe keeps one).
+        assert disks[0]["instance"] is radarr
+
+    def test_free_up_path_restricts_to_one_mount(self, cleaner):
+        radarr = MagicMock()
+        radarr.get_disk_space.return_value = [
+            {"path": "/data", "freeSpace": 100},
+            {"path": "/movies", "freeSpace": 100},
+        ]
+        cleaner.radarr = {"R": radarr}
+        cleaner.sonarr = {}
+
+        disks = cleaner._build_disk_targets(target_bytes=1000, free_up_path="/data")
+
+        assert [d["path"] for d in disks] == ["/data"]
+
+    def test_no_under_target_disks_returns_empty(self, cleaner):
+        radarr = MagicMock()
+        radarr.get_disk_space.return_value = [{"path": "/data", "freeSpace": 9000}]
+        cleaner.radarr = {"R": radarr}
+        cleaner.sonarr = {}
+
+        assert cleaner._build_disk_targets(target_bytes=1000, free_up_path=None) == []
+
+
+# --------------------------------------------------------------------------- #
+# Candidate gathering
+# --------------------------------------------------------------------------- #
+
+class TestGatherCandidates:
+    def test_buckets_candidates_per_disk_in_config_order(self, cleaner):
+        radarr = MagicMock()
+        sonarr = MagicMock()
+        sonarr.get_series.return_value = []
+        cleaner.radarr = {"R": radarr}
+        cleaner.sonarr = {"S": sonarr}
+        cleaner.config.settings["libraries"] = [
+            {"name": "Movies", "radarr": "R"},
+            {"name": "Shows", "sonarr": "S"},
+        ]
+
+        def fake_candidates(library, instance, media_type, all_data):
+            if media_type == "movie":
+                return [_movie("A", "/data/movies/A", 100)]
+            return [{"title": "S1", "path": "/data/tv/S1", "statistics": {"sizeOnDisk": 200}}]
+
+        cleaner.media_cleaner.get_ordered_candidates.side_effect = fake_candidates
+
+        disk = {"path": "/data", "free_space": 0, "target": 1000,
+                "deficit": 1000, "libraries": [], "instance": radarr}
+        cleaner._gather_candidates([disk], target_bytes=1000)
+
+        # Both libraries mapped onto /data, in config order (Movies then Shows).
+        assert [q["library"]["name"] for q in disk["libraries"]] == ["Movies", "Shows"]
+        assert cleaner.libraries_processed == 2
+
+    def test_candidates_on_other_disks_are_dropped(self, cleaner):
+        radarr = MagicMock()
+        cleaner.radarr = {"R": radarr}
+        cleaner.sonarr = {}
+        cleaner.config.settings["libraries"] = [{"name": "Movies", "radarr": "R"}]
+        cleaner.media_cleaner.get_ordered_candidates.return_value = [
+            _movie("OnDisk", "/data/movies/OnDisk", 100),
+            _movie("Elsewhere", "/other/movies/Elsewhere", 100),
+        ]
+
+        disk = {"path": "/data", "free_space": 0, "target": 1000,
+                "deficit": 1000, "libraries": [], "instance": radarr}
+        cleaner._gather_candidates([disk], target_bytes=1000)
+
+        titles = [i["title"] for q in disk["libraries"] for i in q["queue"]]
+        assert titles == ["OnDisk"]
+
+
+# --------------------------------------------------------------------------- #
+# Round-robin deletion
+# --------------------------------------------------------------------------- #
+
+class TestProcessDisk:
+    def _disk(self, cleaner, free_space, target, libraries):
+        return {
+            "path": "/data",
+            "free_space": free_space,
+            "target": target,
+            "deficit": target - free_space,
+            "freed": 0,
+            "final_free": free_space,
+            "instance": MagicMock(),
+            "libraries": libraries,
+        }
+
+    def test_round_robin_order_and_stops_at_target(self, cleaner):
+        libA = _library_queue("A", "R", "movie",
+                              [_movie("a1", "/data/a1", 100),
+                               _movie("a2", "/data/a2", 100),
+                               _movie("a3", "/data/a3", 100)], cleaner)
+        libB = _library_queue("B", "R", "movie",
+                              [_movie("b1", "/data/b1", 100),
+                               _movie("b2", "/data/b2", 100)], cleaner)
+        disk = self._disk(cleaner, free_space=0, target=500, libraries=[libA, libB])
+
+        cleaner._process_disk(disk)
+
+        deleted = [d.title for d in cleaner.run_result.deleted_items]
+        # A, B, A, B, A -> exactly 500 freed, then stop.
+        assert deleted == ["a1", "b1", "a2", "b2", "a3"]
+        assert disk["freed"] == 500
+        assert disk["final_free"] == 500
+
+    def test_stops_immediately_when_target_met_midway(self, cleaner):
+        libA = _library_queue("A", "R", "movie",
+                              [_movie("a1", "/data/a1", 100),
+                               _movie("a2", "/data/a2", 100),
+                               _movie("a3", "/data/a3", 100)], cleaner)
+        libB = _library_queue("B", "R", "movie",
+                              [_movie("b1", "/data/b1", 100),
+                               _movie("b2", "/data/b2", 100)], cleaner)
+        disk = self._disk(cleaner, free_space=0, target=250, libraries=[libA, libB])
+
+        cleaner._process_disk(disk)
+
+        deleted = [d.title for d in cleaner.run_result.deleted_items]
+        assert deleted == ["a1", "b1", "a2"]  # 300 >= 250, stop
+        # Untouched candidates remain queued.
+        assert [i["title"] for i in libA["queue"]] == ["a3"]
+        assert [i["title"] for i in libB["queue"]] == ["b2"]
+
+    def test_actually_calls_delete_when_not_dry_run(self, cleaner):
+        cleaner.is_dry_run = False
+        entry = _library_queue("A", "R", "movie", [_movie("a1", "/data/a1", 1000)], cleaner)
+        disk = self._disk(cleaner, free_space=0, target=500, libraries=[entry])
+
+        cleaner._process_disk(disk)
+
+        cleaner.media_cleaner.delete_movie_if_allowed.assert_called_once()
+
+    def test_dry_run_deletes_nothing_but_accounts_space(self, cleaner):
+        cleaner.is_dry_run = True
+        entry = _library_queue("A", "R", "movie",
+                              [_movie("a1", "/data/a1", 300),
+                               _movie("a2", "/data/a2", 300)], cleaner)
+        disk = self._disk(cleaner, free_space=0, target=500, libraries=[entry])
+
+        cleaner._process_disk(disk)
+
+        cleaner.media_cleaner.delete_movie_if_allowed.assert_not_called()
+        assert disk["freed"] == 600  # both counted optimistically
+        assert len(cleaner.run_result.deleted_items) == 2
+
+    def test_unreachable_target_warns_and_frees_what_it_can(self, cleaner):
+        entry = _library_queue("A", "R", "movie",
+                              [_movie("a1", "/data/a1", 100),
+                               _movie("a2", "/data/a2", 100),
+                               _movie("a3", "/data/a3", 100)], cleaner)
+        disk = self._disk(cleaner, free_space=0, target=1000, libraries=[entry])
+
+        cleaner._process_disk(disk)
+
+        assert disk["freed"] == 300
+        assert disk["final_free"] == 300  # below target, but no infinite loop
+        assert len(cleaner.run_result.deleted_items) == 3
+
+    def test_series_deletion_skip_not_counted(self, cleaner):
+        cleaner.is_dry_run = False
+        # delete_series returns False (e.g. episode file in use) -> not counted.
+        cleaner.media_cleaner.delete_series.return_value = False
+        entry = {
+            "library": {"name": "TV", "sonarr": "S"},
+            "instance": MagicMock(),
+            "media_type": "show",
+            "queue": [{"title": "S1", "path": "/data/tv/S1",
+                       "statistics": {"sizeOnDisk": 400}}],
+        }
+        disk = self._disk(cleaner, free_space=0, target=300, libraries=[entry])
+
+        cleaner._process_disk(disk)
+
+        assert disk["freed"] == 0
+        assert cleaner.run_result.deleted_items == []
+
+    def test_drift_correction_requeries_free_space(self, cleaner):
+        cleaner.is_dry_run = False
+        instance = MagicMock()
+        # After the 10th deletion the disk really has plenty free.
+        instance.get_disk_space.return_value = [{"path": "/data", "freeSpace": 2100}]
+        items = [_movie(f"m{i}", f"/data/m{i}", 100) for i in range(15)]
+        entry = {
+            "library": {"name": "Movies", "radarr": "R"},
+            "instance": MagicMock(),
+            "media_type": "movie",
+            "queue": items,
+        }
+        disk = self._disk(cleaner, free_space=0, target=2000, libraries=[entry])
+        disk["instance"] = instance
+
+        cleaner._process_disk(disk)
+
+        # Optimistic sum after 10 deletions is 1000; the re-query bumps free space
+        # to 2100 >= 2000, so we stop at 10 rather than exhausting all 15.
+        instance.get_disk_space.assert_called()
+        assert len(cleaner.run_result.deleted_items) == 10
+        assert disk["final_free"] == 2100
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end run wiring
+# --------------------------------------------------------------------------- #
+
+class TestRun:
+    def test_run_no_disks_short_circuits(self, cleaner):
+        cleaner._build_disk_targets = MagicMock(return_value=[])
+        cleaner._gather_candidates = MagicMock()
+
+        cleaner.run(target_bytes=1000)
+
+        cleaner._gather_candidates.assert_not_called()
+        assert cleaner.run_result.end_time is not None
+
+    def test_run_processes_each_disk(self, cleaner):
+        disk1 = {"path": "/data", "target": 1000, "deficit": 1000,
+                 "free_space": 0, "final_free": 0, "freed": 0, "libraries": []}
+        disk2 = {"path": "/media", "target": 1000, "deficit": 1000,
+                 "free_space": 0, "final_free": 0, "freed": 0, "libraries": []}
+        cleaner._build_disk_targets = MagicMock(return_value=[disk1, disk2])
+        cleaner._gather_candidates = MagicMock()
+        cleaner._process_disk = MagicMock()
+
+        cleaner.run(target_bytes=1000, free_up_path="/x")
+
+        assert cleaner._process_disk.call_count == 2
+        cleaner._build_disk_targets.assert_called_once_with(1000, "/x")


### PR DESCRIPTION
Implements #299.

- Adds `--free-up <SIZE>` (with `--free-up-path` and `--dry-run`): an on-demand, cross-library cleanup that deletes immediately until each disk hits a free-space target, then stops.
- New `app/on_demand.py` `OnDemandCleaner`, organized per disk: build under-target disk targets from `get_disk_space()` (dedupe same mount), gather ordered candidates from every library, map each to its disk by longest-prefix, round-robin delete across libraries one item at a time re-checking the target after each deletion.
- Bypasses the leaving_soon grace period (immediate hard delete) but honors all protections (exclusions, genres, Trakt/mdblist, watch/added thresholds) and each library's `sort` by reusing `process_library_rules` via a new `MediaCleaner.get_ordered_candidates()`. Only `max_actions_per_run` and the per-library disk gate are overridden.
- Drift correction: optimistic `sizeOnDisk` accounting between real `get_disk_space()` re-queries every 10 deletions.
- Reuses `RunResult`/`DeletedItem`/notifications, with a per-disk "freed X / now Y free" summary. Warns when a target is unreachable.
- Lock collision (open question in the issue): `--free-up` proceeds anyway if the scheduler is mid-run, since it is an explicit emergency action.
- CLI-only, no schema change. Docs section added to the generator source and regenerated.
- Adds `tests/modules/test_on_demand.py` (19 tests): stops-at-target, per-disk accounting, round-robin ordering, dedupe, path->disk mapping, protections honored, dry-run deletes nothing, series-skip not counted, drift-correction re-query, unreachable target.